### PR TITLE
feat: dialog 컴포넌트 구현

### DIFF
--- a/src/shared/components/dialog/dialog.tsx
+++ b/src/shared/components/dialog/dialog.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react';
+
+interface DialogProps {
+  ment?: string;
+  children?: ReactNode;
+}
+const Dialog = ({ ment, children }: DialogProps) => {
+  return (
+    <div>
+      <p>{ment}</p>
+      {children}
+    </div>
+  );
+};
+
+export default Dialog;

--- a/src/shared/components/dialog/dialog.tsx
+++ b/src/shared/components/dialog/dialog.tsx
@@ -1,13 +1,13 @@
 import type { ReactNode } from 'react';
 
 interface DialogProps {
-  ment?: string;
+  info?: ReactNode;
   children?: ReactNode;
 }
-const Dialog = ({ ment, children }: DialogProps) => {
+const Dialog = ({ info, children }: DialogProps) => {
   return (
-    <div>
-      <p>{ment}</p>
+    <div className="w-[34.3rem] flex-col-center rounded-[1.6rem] bg-gray-white px-[3.2rem] pt-[4rem] pb-[3.2rem] shadow-1">
+      <p className="subhead_18_sb text-center">{info}</p>
       {children}
     </div>
   );

--- a/src/shared/styles/global.css
+++ b/src/shared/styles/global.css
@@ -16,8 +16,8 @@
 
   body {
     font-family:
-      "Pretendard", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
-      Arial, sans-serif;
+      "Pretendard", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial,
+      sans-serif;
     min-width: var(--min-width);
     max-width: var(--max-width);
     margin-left: auto;

--- a/src/shared/styles/global.css
+++ b/src/shared/styles/global.css
@@ -16,7 +16,7 @@
 
   body {
     font-family:
-      "Pretendard Variable", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
+      "Pretendard", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
       Arial, sans-serif;
     min-width: var(--min-width);
     max-width: var(--max-width);


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #51

## ☀️ New-insight
- global에 fontfamily를 지정할때는 그 CDN에서 지정한 이름과 일치해야 한다.

## 💎 PR Point
- 묘하게 pretenadrd 인듯 pretendard 아닌 pretendard 같아서 보니까 global에 `font-family: pretendard variable`으로 작성되어 있었는데, 우리가 index.html에 삽입한 CDN 링크 (프리텐다드 가변체)에서 제공하는 font family의 이름은 그냥 pretendard 였습니다. 변경해주었더니 폰트 바로 적용되었습니다 ~! ` font-family:
      "Pretendard",`

### Dialog 컴포넌트 사용법

```ts
interface DialogProps {
  info?: ReactNode;
  children?: ReactNode;
}
const Dialog = ({ info, children }: DialogProps) => {
  return (
    <div className="w-[34.3rem] flex-col-center rounded-[1.6rem] bg-gray-white px-[3.2rem] pt-[4rem] pb-[3.2rem] shadow-1">
      <p className="subhead_18_sb text-center">{info}</p>
      {children}
    </div>
  );
};

export default Dialog;
```

- 안에 들어가는 글씨는 p태그 (info)로, 그리고 버튼같은 경우는 children으로 받을 수 있게 작성해두었습니다. 예원님이 구현해준 버튼이 들어갈 자리에요.

### 예시코드
```ts
 <Dialog
        info={
          <>
            최소 1회의 매칭 조건을 설정해 주셔야
            <br />
            다른 사용자들과의 매칭을 <br /> 추천해드릴 수 있어요!
          </>
        }
      >
        <button type="button" className="bg-blue-600 px-[0.8rem] py-[1.2rem] text-white">
          버튼
        </button>
      </Dialog>
```

- 다만, 줄바꿈을 의도한대로 하기 위해서 info를 일반 string이 아닌 ReactNode로 선언해두었어요, 원하는 줄바꿈 위치에서 `<br/>` 사용해주시면 됩니당
- 
## 📸 Screenshot
![image](https://github.com/user-attachments/assets/78fe186b-ca25-4df3-8989-ea1bccefd41a)
