### PR TITLE
fix: chromatic 댓글 중복 방지 처리 및 pre-commit 권한 문제 해결

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -48,7 +48,6 @@ jobs:
           body-includes: "<!-- chromatic-storybook-deployment -->"
 
       - name: Add PR comment for Chromatic deployment
-        if: steps.find_comment.outputs.comment-id == ''
         uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -48,6 +48,7 @@ jobs:
           body-includes: "<!-- chromatic-storybook-deployment -->"
 
       - name: Add PR comment for Chromatic deployment
+        if: steps.find_comment.outputs.comment-id == ''
         uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,2 @@
-chmod +x .husky/pre-commit
-
 pnpm biome format --write .
 pnpm biome check .
-


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #69 

## ☀️ New-insight

**❶ chromatic 댓글 중복 방지**
chromatic 워크플로우에서 pr마다 댓글이 중복으로 달리던 문제는 `create-or-update-comment`가 매번 실행되기 때문이었어요.
이를 방지하기 위해 `find-comment` 액션을 사용해 이미 댓글이 존재하는 경우에는 새로 작성하지 않도록 조건`(if: steps.find_comment.outputs.comment-id == ''`)을 추가했습니다.

**❷ husky pre-commit 안정화**
`.husky/pre-commit` 스크립트에 `chmod +x .husky/pre-commit` 명령어가 들어가 있었는데, 이로 인해 실행 권한이 꼬이거나 파일이 덮어씌워져서 마지막 줄이 사라지는 현상이 반복되고 있었어요..
해당 명령어는 **터미널에서 한 번만 실행하면 되는 작업**이기 때문에, 스크립트 내부에 있을 필요가 없다고 해요. husky hook이 안정적으로 동작하려면 스크립트는 내용만 유지하고 실행 권한은 `chmod`로 별도 관리하는 게 좋을 것 같아 삭제했습니다.

## 💎 PR Point
- `peter-evans/find-comment`를 사용해 고유한 주석(`<!-- chromatic-storybook-deployment -->`)이 포함된 댓글을 먼저 찾아보고, 이미 존재한다면 `create-or-update-comment` step은 생략되도록 조건 처리했습니다.
- `chmod +x`는 셸 명령어로서 **수동으로 한 번만 실행하면 되는 명령**이며, 파일 내부에서 제거했습니다. 
- 혹시 제가 틀렸다면,, 말해주세요 ㅎㅎ ㅠ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Chromatic 배포 PR 댓글이 중복 생성되지 않도록 워크플로우 조건을 추가했습니다.
  * pre-commit 훅에서 실행 권한을 설정하는 명령어를 제거했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->