### PR TITLE
fix: use-funnel 훅 개선

### DIFF
--- a/src/shared/hooks/use-funnel.tsx
+++ b/src/shared/hooks/use-funnel.tsx
@@ -7,6 +7,7 @@ interface FunnelProps {
 }
 
 interface StepProps {
+  name: string;
   children: ReactNode;
 }
 

--- a/src/shared/hooks/use-funnel.tsx
+++ b/src/shared/hooks/use-funnel.tsx
@@ -20,10 +20,15 @@ export const useFunnel = <T extends readonly string[]>(steps: T, completePath: s
   const currentStep = steps[currentIndex];
 
   useEffect(() => {
+    if (!stepFromUrl) {
+      setSearchParams({ step: steps[0] }, { replace: true });
+      return;
+    }
+
     if (!isValidStep) {
       navigate(ROUTES.ERROR, { replace: true });
     }
-  }, [isValidStep, navigate]);
+  }, [stepFromUrl, isValidStep, setSearchParams, steps, navigate]);
 
   const goTo = useCallback(
     (step: T[number]) => {


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #100 

## ☀️ New-insight

- step 쿼리 파라미터가 없는 상태로 퍼널 페이지에 최초 진입하면 isValidStep이 false로 처리되어, 곧바로 에러 페이지로 이동하는 문제가 있었습니다.

## 💎 PR Point

- 퍼널 페이지에 step 파라미터 없이 진입할 경우, 기본값인 `steps[0]`으로 리디렉션되도록 처리했습니다.
```ts
if (!stepFromUrl) {
  setSearchParams({ step: steps[0] }, { replace: true });
  return;
}
```
- 잘못된 step 값에 대해서는 기존과 동일하게 에러 페이지로 이동합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **버그 수정**
  * URL에 `step` 쿼리 파라미터가 없을 경우, 첫 번째 단계로 자동 초기화되어 올바른 단계로 이동하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->