### PR TITLE
style: tab 스타일 수정 (#121)

### DIFF
--- a/src/shared/components/tab/tab/styles/tab-style.ts
+++ b/src/shared/components/tab/tab/styles/tab-style.ts
@@ -1,20 +1,22 @@
 export const tabStyleMap = {
   dark: {
-    gap: 'gap-[2.4rem]',
+    gap: 'gap-[1.2rem]',
     textActive: 'text-gray-white',
     textInactive: 'text-gray-500',
-    borderActive: 'border-gray-white',
+    borderActive: 'border-sub-900',
     borderInactive: 'border-transparent',
-    height: 'h-[3.9rem]',
+    borderThickness: 'border-b-[0.4rem]',
+    size: 'h-[3.9rem] w-[5.6rem]',
     typography: 'subhead_18_sb',
   },
   light: {
-    gap: 'gap-[0.8rem]',
+    gap: 'gap-[2.4rem]',
     textActive: 'text-gray-black',
     textInactive: 'text-gray-600',
     borderActive: 'border-gray-black',
     borderInactive: 'border-transparent',
-    height: 'h-[3.0rem]',
+    borderThickness: 'border-b-[0.2rem]',
+    size: 'h-[3.0rem] w-[4.8rem]',
     typography: 'head_20_sb',
   },
 } as const;

--- a/src/shared/components/tab/tab/tab-item.tsx
+++ b/src/shared/components/tab/tab/tab-item.tsx
@@ -15,9 +15,9 @@ const BarTabItem = ({ label, isActive, style, onClick }: BarTabItemProps) => {
       data-active={isActive}
       onClick={onClick}
       className={cn(
-        'w-[4.8rem] border-b-[2px]',
         isActive ? style.borderActive : style.borderInactive,
-        style.height,
+        style.size,
+        style.borderThickness,
         'flex-row-center cursor-pointer whitespace-nowrap py-[0.6rem]',
       )}
     >


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #121

## ☀️ New-insight

기존에는 height 스타일만 다르게 정의했었는데 width도 달라지면서 네이밍을 size로 수정했습니다! `style.size`로 사용하면 됩니다!!

## 💎 PR Point

>tab 컴포넌트에서 border 크기가 달라지고... tab 간 간격이 변경되어서 해당 부분 반영했습니다!

### 테스트 코드
```tsx
import queryClient from '@libs/query-client';
import { QueryClientProvider } from '@tanstack/react-query';
import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
import TabList from '@components/tab/tab/tab-list';

const App = () => {
  return (
    <QueryClientProvider client={queryClient}>
      <div className="min-h-screen p-6 bg-gray-900">
        <h1 className="mb-4 text-xl font-bold text-white">BarTabList 테스트 (home)</h1>
        <TabList colorMode="dark" />

        <h1 className="mt-8 mb-4 text-xl font-bold text-white">BarTabList 테스트 (group)</h1>
        <TabList colorMode="light" />
      </div>
      <ReactQueryDevtools initialIsOpen={false} />
    </QueryClientProvider>
  );
};

export default App;

```

## 📸 Screenshot
<img width="400" alt="image" src="https://github.com/user-attachments/assets/d9e502c0-1493-4459-a743-877189897ffe" />
