### PR TITLE
feat: 그룹 퍼널 전환 시 프로그레스 바 부드럽게 전환

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-	"editor.formatOnSave": true,
+	"editor.formatOnSave": false,
 	"editor.defaultFormatter": "biomejs.biome",
 
 	"[typescript]": {

--- a/src/pages/onboarding/onboarding.tsx
+++ b/src/pages/onboarding/onboarding.tsx
@@ -39,13 +39,18 @@ const Onboarding = () => {
 
   const navigate = useNavigate();
 
+  const [progressOverride, setProgressOverride] = useState<number | null>(null);
+
   return (
     <div className="h-svh flex-col">
       <div className="sticky top-0 bg-background">
         <OnboardingHeader onClick={goPrev} />
         {currentStep !== 'START' && (
           <div className="w-full">
-            <ProgressBar currentStep={currentIndex} totalSteps={steps.length - 1} />
+            <ProgressBar
+              currentStep={progressOverride ?? currentIndex}
+              totalSteps={steps.length - 1}
+            />
           </div>
         )}
       </div>
@@ -102,7 +107,9 @@ const Onboarding = () => {
             size="L"
             variant="blue"
             disabled={isButtonDisabled(currentStep, selections)}
-            onClick={() => handleButtonClick(currentStep, selections, goNext, navigate)}
+            onClick={() =>
+              handleButtonClick(currentStep, selections, goNext, navigate, setProgressOverride)
+            }
           />
         </div>
       </div>

--- a/src/pages/onboarding/utils/onboarding-button.ts
+++ b/src/pages/onboarding/utils/onboarding-button.ts
@@ -25,11 +25,23 @@ export const handleButtonClick = (
   selections: Record<string, string | null>,
   goNext: () => void,
   navigate: NavigateFunction,
+  setProgressOverride?: (step: number) => void,
 ) => {
   if (currentStep === 'START') {
     goNext();
   } else if (currentStep === 'MATCHING_TYPE') {
-    selections.MATCHING_TYPE === '1:1 매칭' ? goNext() : navigate(ROUTES.ONBOARDING_GROUP);
+    if (selections.MATCHING_TYPE === '1:1 매칭') {
+      goNext();
+    } else {
+      if (setProgressOverride) {
+        setProgressOverride(0);
+        setTimeout(() => {
+          navigate(ROUTES.ONBOARDING_GROUP);
+        }, 300);
+      } else {
+        navigate(ROUTES.ONBOARDING_GROUP);
+      }
+    }
   } else if (currentStep === 'COMPLETE') {
     navigate(ROUTES.HOME);
   } else {

--- a/src/pages/onboarding/utils/onboarding-button.ts
+++ b/src/pages/onboarding/utils/onboarding-button.ts
@@ -38,8 +38,6 @@ export const handleButtonClick = (
         setTimeout(() => {
           navigate(ROUTES.ONBOARDING_GROUP);
         }, 300);
-      } else {
-        navigate(ROUTES.ONBOARDING_GROUP);
       }
     }
   } else if (currentStep === 'COMPLETE') {


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #142 

## ☀️ New-insight

progress bar가 온보딩 퍼널과 그룹퍼널에 각각 독립적으로 구현되어 있어서, 라우팅 시 바로 전환되면 progress가 바로 0%로 바뀌는 문제가 있었다. 자연스러운 페이지 전환을 위해 navigate 이전에 progress bar에 0% 애니메이션을 먼저 적용한 뒤 이동하게 했다.

## 💎 PR Point

- `handleButtonClick`에서 `setProgressOverride`를 전달받아 0%로 애니메이션 적용 후 라우팅
- `ProgressBar`는 `progressOverride ?? currentIndex`를 사용해 애니메이션 흐름 반영
- 그룹 매칭 선택 시 자연스럽게 페이지 전환
- 
### 🤔 고민...
- 0.2초 뒤에 navigate 실행할지, 0.3초 뒤에 실행할지 고민하다 0.3초로 설정했는데 어떠신지 아래 영상보고 의견 주시면 감사하겠스므니다..

## 📸 Screenshot

https://github.com/user-attachments/assets/a2ff39a8-3083-4c44-84a1-fc9cfc0a438c
