### PR TITLE
fix: 온보딩 중 새로고침 시 상태 초기화 문제 해결

### DIFF
--- a/src/pages/onboarding/constants/onboarding.ts
+++ b/src/pages/onboarding/constants/onboarding.ts
@@ -34,3 +34,7 @@ export const GENDER = ['남성', '여성', '상관없어요'] as const;
 export const MATCHING_TYPE = ['1:1 매칭', '그룹 매칭'] as const;
 
 export const GROUP_ROLE = ['그룹장', '그룹원'] as const;
+
+export const ONBOARDING_STORAGE_KEY = 'mateball/onboardingSelections';
+
+export const ONBOARDING_GROUP_STORAGE_KEY = 'mateball/onboardingGroupSelections';

--- a/src/pages/onboarding/onboarding-group.tsx
+++ b/src/pages/onboarding/onboarding-group.tsx
@@ -18,7 +18,7 @@ import { ROUTES } from '@routes/routes-config';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-const getStoredSelections = (): Record<string, string | null> => {
+const getStoredSelection = (): Record<string, string | null> => {
   try {
     const stored = localStorage.getItem(ONBOARDING_GROUP_STORAGE_KEY);
     return stored ? JSON.parse(stored) : {};
@@ -35,21 +35,20 @@ const OnboardingGroup = () => {
 
   const navigate = useNavigate();
 
-  const [selections, setSelections] = useState<Record<string, string | null>>(() => {
-    const stored = getStoredSelections();
+  const [selection, setSelection] = useState<Record<string, string | null>>(() => {
+    const stored = getStoredSelection();
     return {
       GROUP_ROLE: stored.GROUP_ROLE ?? null,
-      DATE_SELECT: stored.DATE_SELECT ?? null,
     };
   });
 
   const handleSelect = (stepName: string, value: string) => {
-    setSelections((prev) => ({ ...prev, [stepName]: value }));
+    setSelection((prev) => ({ ...prev, [stepName]: value }));
   };
 
   useEffect(() => {
-    localStorage.setItem(ONBOARDING_GROUP_STORAGE_KEY, JSON.stringify(selections));
-  }, [selections]);
+    localStorage.setItem(ONBOARDING_GROUP_STORAGE_KEY, JSON.stringify(selection));
+  }, [selection]);
 
   return (
     <div className="h-full flex-col">
@@ -66,7 +65,7 @@ const OnboardingGroup = () => {
         <Funnel>
           <Step name="GROUP_ROLE">
             <GroupRole
-              selectedOption={selections.GROUP_ROLE}
+              selectedOption={selection.GROUP_ROLE}
               onSelect={(option) => handleSelect('GROUP_ROLE', option)}
             />
           </Step>
@@ -89,8 +88,8 @@ const OnboardingGroup = () => {
             label={getButtonLabel(currentStep)}
             size="L"
             variant="blue"
-            disabled={isButtonDisabled(currentStep, selections)}
-            onClick={() => handleButtonClick(currentStep, selections, goNext, navigate)}
+            disabled={isButtonDisabled(currentStep, selection)}
+            onClick={() => handleButtonClick(currentStep, selection, goNext, navigate)}
           />
         </div>
       </div>

--- a/src/pages/onboarding/onboarding-group.tsx
+++ b/src/pages/onboarding/onboarding-group.tsx
@@ -5,15 +5,27 @@ import DateSelect from '@pages/onboarding/components/date-select';
 import GroupRole from '@pages/onboarding/components/group-role';
 import OnboardingHeader from '@pages/onboarding/components/onboarding-header';
 import ProgressBar from '@pages/onboarding/components/progress-bar';
-import { GROUP_FUNNEL_STEPS } from '@pages/onboarding/constants/onboarding';
+import {
+  GROUP_FUNNEL_STEPS,
+  ONBOARDING_GROUP_STORAGE_KEY,
+} from '@pages/onboarding/constants/onboarding';
 import {
   getButtonLabel,
   handleButtonClick,
   isButtonDisabled,
 } from '@pages/onboarding/utils/onboarding-button';
 import { ROUTES } from '@routes/routes-config';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+
+const getStoredSelections = (): Record<string, string | null> => {
+  try {
+    const stored = localStorage.getItem(ONBOARDING_GROUP_STORAGE_KEY);
+    return stored ? JSON.parse(stored) : {};
+  } catch {
+    return {};
+  }
+};
 
 const OnboardingGroup = () => {
   const { Funnel, Step, currentStep, currentIndex, steps, goNext, goPrev } = useFunnel(
@@ -23,13 +35,21 @@ const OnboardingGroup = () => {
 
   const navigate = useNavigate();
 
-  const [selections, setSelections] = useState<Record<string, string | null>>({
-    GROUP_ROLE: null,
+  const [selections, setSelections] = useState<Record<string, string | null>>(() => {
+    const stored = getStoredSelections();
+    return {
+      GROUP_ROLE: stored.GROUP_ROLE ?? null,
+      DATE_SELECT: stored.DATE_SELECT ?? null,
+    };
   });
 
   const handleSelect = (stepName: string, value: string) => {
     setSelections((prev) => ({ ...prev, [stepName]: value }));
   };
+
+  useEffect(() => {
+    localStorage.setItem(ONBOARDING_GROUP_STORAGE_KEY, JSON.stringify(selections));
+  }, [selections]);
 
   return (
     <div className="h-full flex-col">

--- a/src/pages/onboarding/onboarding.tsx
+++ b/src/pages/onboarding/onboarding.tsx
@@ -9,15 +9,24 @@ import Start from '@pages/onboarding/components/start';
 import SupportTeam from '@pages/onboarding/components/support-team';
 import SyncSupportTeam from '@pages/onboarding/components/sync-support-team';
 import ViewingStyle from '@pages/onboarding/components/viewing-style';
-import { FIRST_FUNNEL_STEPS } from '@pages/onboarding/constants/onboarding';
+import { FIRST_FUNNEL_STEPS, ONBOARDING_STORAGE_KEY } from '@pages/onboarding/constants/onboarding';
 import {
   getButtonLabel,
   handleButtonClick,
   isButtonDisabled,
 } from '@pages/onboarding/utils/onboarding-button';
 import { ROUTES } from '@routes/routes-config';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+
+const getStoredSelections = (): Record<string, string | null> => {
+  try {
+    const stored = localStorage.getItem(ONBOARDING_STORAGE_KEY);
+    return stored ? JSON.parse(stored) : {};
+  } catch {
+    return {};
+  }
+};
 
 const Onboarding = () => {
   const { Funnel, Step, currentStep, currentIndex, steps, goNext, goPrev } = useFunnel(
@@ -25,12 +34,15 @@ const Onboarding = () => {
     ROUTES.HOME,
   );
 
-  const [selections, setSelections] = useState<Record<string, string | null>>({
-    SUPPORT_TEAM: null,
-    SYNC_SUPPORT_TEAM: null,
-    VIEWING_STYLE: null,
-    GENDER: null,
-    MATCHING_TYPE: null,
+  const [selections, setSelections] = useState<Record<string, string | null>>(() => {
+    const stored = getStoredSelections();
+    return {
+      SUPPORT_TEAM: stored.SUPPORT_TEAM ?? null,
+      SYNC_SUPPORT_TEAM: stored.SYNC_SUPPORT_TEAM ?? null,
+      VIEWING_STYLE: stored.VIEWING_STYLE ?? null,
+      GENDER: stored.GENDER ?? null,
+      MATCHING_TYPE: stored.MATCHING_TYPE ?? null,
+    };
   });
 
   const handleSelect = (stepName: string, value: string) => {
@@ -38,6 +50,10 @@ const Onboarding = () => {
   };
 
   const navigate = useNavigate();
+
+  useEffect(() => {
+    localStorage.setItem(ONBOARDING_STORAGE_KEY, JSON.stringify(selections));
+  }, [selections]);
 
   return (
     <div className="h-svh flex-col">


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #139 

## ☀️ New-insight

온보딩 진행 중 새로고침 하게 되면 컴포넌트 상태(useState)는 초기화되기 때문에, 사용자의 선택값을 유지하기 위해서 localStorage에 저장했어요.

## 💎 PR Point

useState 초기값을 localStorage 기반으로 설정하고, useEffect를 통해 selections가 변경될 때마다 다시 저장되도록 처리했습니다.

