### PR TITLE
feat: 내 정보 페이지 api 연동 

### DIFF
--- a/src/pages/home/components/match-list-section.tsx
+++ b/src/pages/home/components/match-list-section.tsx
@@ -22,7 +22,6 @@ const MatchListSection = ({
   selectedDate,
   onOpenGameInfoBottomSheet,
 }: MatchListSectionProps) => {
-
   const navigate = useNavigate();
 
   const filteredMatches = useMemo(() => {

--- a/src/pages/profile/profile.tsx
+++ b/src/pages/profile/profile.tsx
@@ -1,25 +1,34 @@
+import { userQueries } from '@apis/user/user-queries';
 import Button from '@components/button/button/button';
 import Card from '@components/card/match-card/card';
+import type { ChipColor } from '@components/chip/chip-list';
 import Footer from '@components/footer/footer';
-import { mockProfileData } from '@mocks/mockProfileData';
+import ErrorView from '@pages/error/error-view';
+import { useQuery } from '@tanstack/react-query';
 
 const Profile = () => {
-  const { nickname, imgUrl, team, style, age, gender, introduction } = mockProfileData;
+  const { data } = useQuery(userQueries.USER_INFO());
+
+  if (!data) return <ErrorView message="아직 최초 매칭 조건이 설정되지 않았어요" />;
+
   return (
     <div className="h-full flex-col-between">
       <div className="w-full flex-col-center gap-[1.6rem] px-[1.6rem] pt-[1.6rem] pb-[5.6rem]">
         <Card
           type="user"
-          nickname={nickname}
-          imgUrl={[imgUrl]}
-          team={team}
-          style={style}
-          age={age.replace('세', '')}
-          gender={gender}
-          introduction={introduction}
-          chips={[team, style]}
+          nickname={data.nickname ?? ''}
+          imgUrl={[data.imgUrl ?? '']}
+          team={data.team ?? ''}
+          style={data.style?.replace(/\s+/g, '') ?? ''}
+          age={data.age ?? ''}
+          gender={data.gender ?? ''}
+          introduction={data.introduction ?? ''}
+          chips={[
+            (data.team ?? '') as ChipColor,
+            (data.style ?? '').replace(/\s+/g, '') as ChipColor,
+          ]}
         />
-        <Button size={'L'} label="매칭 조건 재설정 하기" />
+        <Button size="L" label="매칭 조건 재설정 하기" />
       </div>
       <Footer />
     </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,20 +5,20 @@ import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react-swc';
 import { defineConfig } from 'vite';
-// import mkcert from 'vite-plugin-mkcert';
+import mkcert from 'vite-plugin-mkcert';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
 const dirname =
   typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
-  // server: {
-  //   port: 443,
-  //   host: 'dev.mateball.co.kr',
-  //   https: {},
-  // },
+  server: {
+    port: 443,
+    host: 'dev.mateball.co.kr',
+    https: {},
+  },
   plugins: [
-    // mkcert(),
+    mkcert(),
     react(),
     svgSprite({
       iconDirs: [resolve(dirname, 'src/shared/assets/svgs')],


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #163 

## ☀️ New-insight
- 내 정보 페이지 api 연동했습니다! 근데 여기는 최초매칭조건 설정이 된 후에 접근 가능한 페이지라서, 우선 data가 없을 때 Errorview에 아직 최초 매칭 조건이 설정되지 않았어요라고 message를 넣어놨는데, 기/디랑 논의해봐야 할 것 같아요

## 💎 PR Point
- 온보딩 API 연동 후 use-auth 훅에서 condition 값이 바로 갱신되지 않는다면, 온보딩 API를 제출할 때 authQuery를 invalidateQueries로 무효화해서 값을 업데이트해줘야 할 것 같아요. 그래야 마이페이지 접근 시 조건이 올바르게 반영될 수 있을 것 같아요! 작업하실 때 참고해주세요 ㅎㅎ (@bongtta )

## 📸 Screenshot

<img width="240" height="792" alt="image" src="https://github.com/user-attachments/assets/4fe30957-f8ab-430d-b742-bd3ac678ce08" />
