### PR TITLE
refactor: query-key 세분화 작업 진행

### DIFF
--- a/src/pages/home/components/match-list-section.tsx
+++ b/src/pages/home/components/match-list-section.tsx
@@ -22,7 +22,6 @@ const MatchListSection = ({
   selectedDate,
   onOpenGameInfoBottomSheet,
 }: MatchListSectionProps) => {
-
   const navigate = useNavigate();
 
   const filteredMatches = useMemo(() => {

--- a/src/shared/apis/match/match-mutations.ts
+++ b/src/shared/apis/match/match-mutations.ts
@@ -11,7 +11,7 @@ export const matchMutations = {
    */
   CREATE_MATCH: () =>
     mutationOptions<responseTypes, Error, postMatchCreateRequest>({
-      mutationKey: MATCH_KEY.POST_MATCH(),
+      mutationKey: MATCH_KEY.POST.MATCH(),
       mutationFn: ({ gameId, matchType }) => post(END_POINT.POST_MATCH, { gameId, matchType }),
     }),
 
@@ -20,7 +20,7 @@ export const matchMutations = {
    */
   MATCH_CONDITION: () =>
     mutationOptions<responseTypes, Error, postMatchConditionRequest>({
-      mutationKey: MATCH_KEY.POST_MATCH_CONDITION(),
+      mutationKey: MATCH_KEY.POST.CONDITION(),
       mutationFn: ({ team, teamAllowed, style, genderPreference }) =>
         post<responseTypes>(END_POINT.POST_MATCH_CONDITION, {
           team,
@@ -35,17 +35,8 @@ export const matchMutations = {
    */
   MATCH_REQUEST: () =>
     mutationOptions<responseTypes, Error, number>({
-      mutationKey: MATCH_KEY.POST_MATCH_REQUEST('request'),
+      mutationKey: MATCH_KEY.REQUEST.POST(),
       mutationFn: (matchId) => post(END_POINT.POST_MATCH_REQUEST(matchId)),
-    }),
-
-  /**
-   * 승인 완료 -> 요청 대기중 변화
-   */
-  MATCH_STAGE: () =>
-    mutationOptions<responseTypes, Error, number>({
-      mutationKey: MATCH_KEY.PATCH_MATCH_STAGE('stage'),
-      mutationFn: (matchId) => patch(END_POINT.PATCH_MATCH_STAGE(matchId)),
     }),
 
   /**
@@ -53,7 +44,7 @@ export const matchMutations = {
    */
   MATCH_ACCEPT: () =>
     mutationOptions<responseTypes, Error, number>({
-      mutationKey: MATCH_KEY.PATCH_MATCH_ACCEPT('accept'),
+      mutationKey: MATCH_KEY.REQUEST.ACCEPT(),
       mutationFn: (matchId) => patch(END_POINT.PATCH_MATCH_ACCEPT(matchId)),
     }),
 
@@ -62,7 +53,16 @@ export const matchMutations = {
    */
   MATCH_REJECT: () =>
     mutationOptions<responseTypes, Error, number>({
-      mutationKey: MATCH_KEY.PATCH_MATCH_REJECT('reject'),
+      mutationKey: MATCH_KEY.REQUEST.REJECT(),
       mutationFn: (matchId) => patch(END_POINT.PATCH_MATCH_REJECT(matchId)),
+    }),
+
+  /**
+   * 승인 완료 → 요청 대기중 전환
+   */
+  MATCH_STAGE: () =>
+    mutationOptions<responseTypes, Error, number>({
+      mutationKey: MATCH_KEY.PATCH_STAGE(),
+      mutationFn: (matchId) => patch(END_POINT.PATCH_MATCH_STAGE(matchId)),
     }),
 };

--- a/src/shared/apis/match/match-queries.ts
+++ b/src/shared/apis/match/match-queries.ts
@@ -26,20 +26,29 @@ export const matchQueries = {
     }),
 
   /**
-   *  일대일 매칭 생성 결과 조회
+   * 일대일 매칭 결과 조회
    */
   SINGLE_MATCH_RESULT: (matchId: number) =>
     queryOptions<getSingleMatchResultResponse>({
-      queryKey: MATCH_KEY.SINGLE_RESULT(matchId),
+      queryKey: MATCH_KEY.RESULT.SINGLE(matchId),
       queryFn: () => get(END_POINT.GET_SINGLE_RESULT(matchId)),
     }),
 
   /**
-   *  일대일 매칭 리스트 조회
+   * 그룹 매칭 결과 조회
+   */
+  GROUP_MATCH_RESULT: (matchId: number) =>
+    queryOptions<getGroupMatchResultResponse>({
+      queryKey: MATCH_KEY.RESULT.GROUP(matchId),
+      queryFn: () => get(END_POINT.GET_GROUP_RESULT(matchId)),
+    }),
+
+  /**
+   * 일대일 매칭 리스트 조회
    */
   SINGLE_MATCH_LIST: (date: string) =>
     queryOptions<getSingleMatchListResponse>({
-      queryKey: MATCH_KEY.SINGLE_LIST(date),
+      queryKey: MATCH_KEY.LIST.SINGLE(date),
       queryFn: () => get(END_POINT.GET_SINGLE_LIST(date)),
     }),
 
@@ -48,17 +57,8 @@ export const matchQueries = {
    */
   GROUP_MATCH_LIST: (date: string) =>
     queryOptions<getGroupMatchListResponse>({
-      queryKey: MATCH_KEY.GROUP_LIST(date),
+      queryKey: MATCH_KEY.LIST.GROUP(date),
       queryFn: () => get(END_POINT.GET_GROUP_LIST(date)),
-    }),
-
-  /**
-   * 그룹 매칭 생성 결과 조회
-   */
-  GROUP_MATCH_RESULT: (matchId: number) =>
-    queryOptions<getGroupMatchResultResponse>({
-      queryKey: MATCH_KEY.GROUP_RESULT(matchId),
-      queryFn: () => get(END_POINT.GET_GROUP_RESULT(matchId)),
     }),
 
   /**
@@ -66,7 +66,7 @@ export const matchQueries = {
    */
   SINGLE_MATCH_STATUS: (status: string) =>
     queryOptions<getSingleMatchMate>({
-      queryKey: MATCH_KEY.SINGLE_STATUS(status),
+      queryKey: MATCH_KEY.STATUS.SINGLE(status),
       queryFn: () => get(END_POINT.GET_SINGLE_STATUS(status)),
     }),
 
@@ -75,7 +75,7 @@ export const matchQueries = {
    */
   GROUP_MATCH_STATUS: (status: string) =>
     queryOptions<getGroupMatchMate>({
-      queryKey: MATCH_KEY.GROUP_STATUS(status),
+      queryKey: MATCH_KEY.STATUS.GROUP(status),
       queryFn: () => get(END_POINT.GET_GROUP_STATUS(status)),
     }),
 
@@ -84,7 +84,7 @@ export const matchQueries = {
    */
   MATCH_DETAIL: (matchId: number) =>
     queryOptions<getMatchDetailResponse>({
-      queryKey: MATCH_KEY.MATCH_DETAIL(matchId),
+      queryKey: MATCH_KEY.DETAIL(matchId),
       queryFn: () => get(END_POINT.GET_MATCH_DETAIL(matchId)),
     }),
 };

--- a/src/shared/constants/query-key.ts
+++ b/src/shared/constants/query-key.ts
@@ -23,21 +23,33 @@ export const GAME_KEY = {
 export const MATCH_KEY = {
   ALL: ['match'] as const,
 
+  LIST: {
+    SINGLE: (date: string) => [...MATCH_KEY.ALL, 'list', 'single', date] as const,
+    GROUP: (date: string) => [...MATCH_KEY.ALL, 'list', 'group', date] as const,
+  },
+
+  RESULT: {
+    SINGLE: (matchId: number) => [...MATCH_KEY.ALL, 'result', 'single', matchId] as const,
+    GROUP: (matchId: number) => [...MATCH_KEY.ALL, 'result', 'group', matchId] as const,
+  },
+
+  STATUS: {
+    SINGLE: (status: string) => [...MATCH_KEY.ALL, 'status', 'single', status] as const,
+    GROUP: (status: string) => [...MATCH_KEY.ALL, 'status', 'group', status] as const,
+  },
+
+  POST: {
+    MATCH: () => [...MATCH_KEY.ALL, 'post', 'match'] as const,
+    CONDITION: () => [...MATCH_KEY.ALL, 'post', 'condition'] as const,
+  },
+
+  REQUEST: {
+    POST: (key?: string) => [...MATCH_KEY.ALL, 'request', 'post', key] as const,
+    ACCEPT: (key?: string) => [...MATCH_KEY.ALL, 'request', 'accept', key] as const,
+    REJECT: (key?: string) => [...MATCH_KEY.ALL, 'request', 'reject', key] as const,
+  },
+
+  DETAIL: (matchId: number) => [...MATCH_KEY.ALL, 'detail', matchId] as const,
   USERS_NUM_COUNT: (matchId: number) => [...MATCH_KEY.ALL, 'usersNumCount', matchId] as const,
-  SINGLE_RESULT: (matchId: number) => [...MATCH_KEY.ALL, 'singleResult', matchId] as const,
-  SINGLE_LIST: (date: string) => [...MATCH_KEY.ALL, 'singleList', date] as const,
-  GROUP_LIST: (date: string) => [...MATCH_KEY.ALL, 'groupList', date] as const,
-  GROUP_RESULT: (matchId: number) => [...MATCH_KEY.ALL, 'groupResult', matchId] as const,
-
-  POST_MATCH: () => [...MATCH_KEY.ALL, 'postMatch'] as const,
-  POST_MATCH_CONDITION: () => [...MATCH_KEY.ALL, 'postMatchCondition'] as const,
-
-  SINGLE_STATUS: (status: string) => [...MATCH_KEY.ALL, 'singleStatus', status] as const,
-  GROUP_STATUS: (status: string) => [...MATCH_KEY.ALL, 'groupStatus', status] as const,
-
-  MATCH_DETAIL: (matchId: number) => [...MATCH_KEY.ALL, 'matchDetail', matchId] as const,
-  POST_MATCH_REQUEST: (key?: string) => [...MATCH_KEY.ALL, 'postMatchRequest', key] as const,
-  PATCH_MATCH_ACCEPT: (key?: string) => [...MATCH_KEY.ALL, 'patchMatchAccept', key] as const,
-  PATCH_MATCH_REJECT: (key?: string) => [...MATCH_KEY.ALL, 'patchMatchReject', key] as const,
-  PATCH_MATCH_STAGE: (key?: string) => [...MATCH_KEY.ALL, 'patchMatchStage', key] as const,
+  PATCH_STAGE: (key?: string) => [...MATCH_KEY.ALL, 'patch', 'stage', key] as const,
 } as const;


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #165 

## ☀️ New-insight
기존에는 MATCH_KEY에 모든 쿼리 키가 평행하게 나열되어 있어, 어떤 키가 어떤 기능 (리스트 반환, 결과, 요청 등)에 해당하는지 구분이 어려웠습니다. 특히 invalidateQuries 시 어떤 키를 무효화해야 하는지 명확하게 알기 어려웠습니다.

따라서 이번 작업을 통해 MATCH_KEY를 LIST, RESULT, STATUS, POST, REQUEST 등 기능 중심으로 계층화하면서, 기능 단위로 더 명확히 사용할 수 있게 되었습니다.


## 💎 PR Point
- MATCH_KEY 구조를 기능별로 계층화 해 리스트, 요청, 결과, 상태 등을 명확히 구분했습니다.
- ex: 기존 `MATHC_KEY.SIGNLE_LIST(data)` -> `MATCH_KEY.LIST.SIGNLE(date)`
- matchQueries, matchMutations도 새 구조에 맞춰 key를 수정했습니다.
- 이제 매칭 생성 이후 리스트만 선택적으로 무효화도 가능하고, 기능별로 명확한 기능을 수행할 수 있게 되었습니다. 추후 확장시 유지 보수성 및 예측 가능성이 올라갈 것이라 기대합니다.

## 📸 Screenshot

### 🔁 MATCH_KEY 변경 전/후 비교표

| 기능 구분           | 기존 MATCH_KEY                         | 변경 후 MATCH_KEY            |
|--------------------|----------------------------------------|------------------------------|
| 전체 키            | `MATCH_KEY.ALL`                        | `MATCH_KEY.ALL`              |
| 1:1 매칭 리스트     | `MATCH_KEY.SINGLE_LIST(date)`          | `MATCH_KEY.LIST.SINGLE(date)`|
| 그룹 매칭 리스트    | `MATCH_KEY.GROUP_LIST(date)`           | `MATCH_KEY.LIST.GROUP(date)` |
| 1:1 매칭 결과       | `MATCH_KEY.SINGLE_RESULT(id)`          | `MATCH_KEY.RESULT.SINGLE(id)`|
| 그룹 매칭 결과      | `MATCH_KEY.GROUP_RESULT(id)`           | `MATCH_KEY.RESULT.GROUP(id)` |
| 1:1 매칭 현황       | `MATCH_KEY.SINGLE_STATUS(status)`      | `MATCH_KEY.STATUS.SINGLE(status)` |
| 그룹 매칭 현황      | `MATCH_KEY.GROUP_STATUS(status)`       | `MATCH_KEY.STATUS.GROUP(status)`  |
| 매칭 상세 정보      | `MATCH_KEY.MATCH_DETAIL(id)`           | `MATCH_KEY.DETAIL(id)`       |
| 매칭 생성          | `MATCH_KEY.POST_MATCH()`               | `MATCH_KEY.POST.MATCH()`     |
| 조건 설정          | `MATCH_KEY.POST_MATCH_CONDITION()`     | `MATCH_KEY.POST.CONDITION()` |
| 매칭 요청          | `MATCH_KEY.POST_MATCH_REQUEST(key)`    | `MATCH_KEY.REQUEST.POST()`   |
| 요청 수락          | `MATCH_KEY.PATCH_MATCH_ACCEPT(key)`    | `MATCH_KEY.REQUEST.ACCEPT()` |
| 요청 거절          | `MATCH_KEY.PATCH_MATCH_REJECT(key)`    | `MATCH_KEY.REQUEST.REJECT()` |
| 요청 상태 전환     | `MATCH_KEY.PATCH_MATCH_STAGE(key)`     | `MATCH_KEY.PATCH_STAGE()`    |
| 매칭 인원 수 조회   | `MATCH_KEY.USERS_NUM_COUNT(id)`        | `MATCH_KEY.USERS_NUM_COUNT(id)` |


<img width="1000" height="343" alt="image" src="https://github.com/user-attachments/assets/25a69174-8909-4912-83d3-6fa9ddfe6980" />

다들 연결 작업하실때 Tanstack Query Dev Tools를 적극 이용해보세요 ㅎㅎ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 매칭 관련 쿼리 및 뮤테이션 키 구조를 계층적으로 그룹화하여 명확성과 일관성을 높였습니다.
  * 기존 평면 구조의 키를 카테고리별 중첩 구조로 변경하였습니다.
  * 주석을 개선하여 각 쿼리의 역할을 더 명확하게 설명합니다.

* **Style**
  * 불필요한 공백 한 줄을 제거하여 코드 가독성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->