### PR TITLE
fix: home scroll 수정

### DIFF
--- a/src/pages/home/components/calendar-section.tsx
+++ b/src/pages/home/components/calendar-section.tsx
@@ -25,7 +25,7 @@ const CalendarSection = ({
   };
 
   return (
-    <section className="sticky top-[5.6rem] z-[var(--z-under-header-section)] bg-gray-black px-[1.6rem] pt-[2.4rem]">
+    <section className="sticky top-0 z-[var(--z-under-header-section)] bg-gray-black px-[1.6rem] pt-[2.4rem]">
       <WeekCalendar
         baseDate={baseWeekDate}
         value={selectedDate}

--- a/src/pages/home/components/calendar-section.tsx
+++ b/src/pages/home/components/calendar-section.tsx
@@ -25,7 +25,7 @@ const CalendarSection = ({
   };
 
   return (
-    <section className="sticky top-[5.6rem] z-[var(--z-home-calendar-section)] bg-gray-black px-[1.6rem] pt-[2.4rem]">
+    <section className="sticky top-0 z-[var(--z-home-calendar-section)] bg-gray-black px-[1.6rem] pt-[2.4rem]">
       <WeekCalendar
         baseDate={baseWeekDate}
         value={selectedDate}

--- a/src/pages/home/components/match-list-section.tsx
+++ b/src/pages/home/components/match-list-section.tsx
@@ -22,7 +22,6 @@ const MatchListSection = ({
   selectedDate,
   onOpenGameInfoBottomSheet,
 }: MatchListSectionProps) => {
-
   const navigate = useNavigate();
 
   const filteredMatches = useMemo(() => {
@@ -40,7 +39,7 @@ const MatchListSection = ({
   };
 
   return (
-    <section className="p-[1.6rem]">
+    <section className="p-[1.6rem] ">
       <ButtonCreate
         label="맞춤 매칭 생성하기"
         className="ml-auto"

--- a/src/pages/home/utils/match-card-renderers.tsx
+++ b/src/pages/home/utils/match-card-renderers.tsx
@@ -24,7 +24,7 @@ export const getCommonProps = (match: SingleMatch | GroupMatch) => ({
 });
 
 export const renderSingleCard = (match: SingleMatch, onCardClick: (matchId: number) => void) => (
-  <button type="button" onClick={() => onCardClick(match.id)} className="cursor-pointer">
+  <button type="button" onClick={() => onCardClick(match.id)} className="w-full cursor-pointer">
     <Card
       id={match.id}
       key={match.id}
@@ -39,7 +39,7 @@ export const renderSingleCard = (match: SingleMatch, onCardClick: (matchId: numb
   </button>
 );
 export const renderGroupCard = (match: GroupMatch, onCardClick: (matchId: number) => void) => (
-  <button type="button" onClick={() => onCardClick(match.id)} className="cursor-pointer">
+  <button type="button" onClick={() => onCardClick(match.id)} className="w-full cursor-pointer">
     <Card
       id={match.id}
       key={match.id}

--- a/src/shared/routes/layout.tsx
+++ b/src/shared/routes/layout.tsx
@@ -18,10 +18,10 @@ const Layout = () => {
   return (
     <div className={cn('h-full flex-col', isFail && 'bg-gray-black')}>
       {showHeader && <Header />}
-      <main className="flex-grow">
+      <main className="scrollbar-hide flex-grow overflow-y-auto">
         <Outlet />
+        {pathname === ROUTES.HOME && <Footer />}
       </main>
-      {pathname === ROUTES.HOME && <Footer />}
       {showBottomNav && <BottomNavigation />}
     </div>
   );

--- a/src/shared/routes/layout.tsx
+++ b/src/shared/routes/layout.tsx
@@ -18,10 +18,12 @@ const Layout = () => {
   return (
     <div className={cn('h-full flex-col', isFail && 'bg-gray-black')}>
       {showHeader && <Header />}
-      <main className="scrollbar-hide flex-grow overflow-y-auto">
-        <Outlet />
+      <div className="scrollbar-hide flex-grow overflow-y-auto">
+        <main>
+          <Outlet />
+        </main>
         {pathname === ROUTES.HOME && <Footer />}
-      </main>
+      </div>
       {showBottomNav && <BottomNavigation />}
     </div>
   );

--- a/src/shared/styles/global.css
+++ b/src/shared/styles/global.css
@@ -14,8 +14,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow-y: auto;
-    scrollbar-width: none;
   }
 
   html {


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #160 

## ☀️ New-insight

<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->

## 💎 PR Point

- 홈에서 헤더와 푸터 영역에서 스크롤이 먹는 문제 해결
overflow-y-scroll이 root에 먹혀 있어서 root안에 들어있는 헤더와 푸터까지 스크롤이 먹는 문제가 있었습니다.
따라서 root의 스크롤 스타일을 빼고, layout에서 main과 푸터 영역을 div로 감싸서 그 div에 스크롤을 넣었습니다.
- 홈 카드 너비 줄어드는 문제 해결


## 📸 Screenshot
