### PR TITLE
feat: 게임 정보 API 연동

### DIFF
--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -58,7 +58,7 @@ const Home = () => {
         isOpen={isGameInfoBottomSheetOpen}
         onClose={() => setIsGameInfoBottomSheetOpen(false)}
         date={format(selectedDate, 'yyyy-MM-dd')}
-        gameSchedule={data}
+        gameSchedule={data ?? []}
         activeType={activeType}
       />
     </div>

--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -1,26 +1,15 @@
-import { useEffect, useState } from 'react';
-import { format, addDays } from 'date-fns';
-
-import TopSection from '@pages/home/components/top-section';
-import CalendarSection from '@pages/home/components/calendar-section';
-import MatchListSection from '@pages/home/components/match-list-section';
-import CalendarBottomSheet from '@pages/home/components/calendar-bottom-sheet';
 import GameMatchBottomSheet from '@components/bottom-sheet/game-match/game-match-bottom-sheet';
-
-import { useTabState } from '@hooks/use-tab-state';
 import { WEEK_CALENDAR_START_OFFSET } from '@components/calendar/constants/CALENDAR';
 import { getInitialSelectedDate } from '@components/calendar/utils/date-grid';
-import { get } from '@apis/base/http';
-import { END_POINT } from '@constants/api';
-import type { ApiResponse } from '@/shared/types/base-types';
-
-interface GameSchedule {
-  id: number;
-  awayTeam: string;
-  homeTeam: string;
-  gameTime: string;
-  stadium: string;
-}
+import { useTabState } from '@hooks/use-tab-state';
+import CalendarBottomSheet from '@pages/home/components/calendar-bottom-sheet';
+import CalendarSection from '@pages/home/components/calendar-section';
+import MatchListSection from '@pages/home/components/match-list-section';
+import TopSection from '@pages/home/components/top-section';
+import { addDays, format } from 'date-fns';
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { gameQueries } from '@apis/game/game-queries';
 
 const Home = () => {
   const { activeType, changeTab, isSingle, isGroup } = useTabState();
@@ -29,34 +18,16 @@ const Home = () => {
 
   const [selectedDate, setSelectedDate] = useState(initialSelectedDate);
   const [baseWeekDate, setBaseWeekDate] = useState(
-    addDays(initialSelectedDate, WEEK_CALENDAR_START_OFFSET)
+    addDays(initialSelectedDate, WEEK_CALENDAR_START_OFFSET),
   );
   const [isCalendarBottomSheetOpen, setIsCalendarBottomSheetOpen] = useState(false);
   const [isGameInfoBottomSheetOpen, setIsGameInfoBottomSheetOpen] = useState(false);
-  const [gameSchedule, setGameSchedule] = useState<GameSchedule[]>([]);
-
+  const dateStr = format(selectedDate, 'yyyy-MM-dd');
+  const { data } = useQuery(gameQueries.GAME_LIST(dateStr));
   const handleDateSelect = (date: Date) => {
     setSelectedDate(date);
     setBaseWeekDate(date);
   };
-
-useEffect(() => {
-  const fetchGameSchedule = async () => {
-    const dateStr = format(selectedDate, 'yyyy-MM-dd');
-    try {
-      const res = await get<ApiResponse<{ gameSchedule: GameSchedule[] }>>(
-        END_POINT.GET_GAME_SCHEDULE(dateStr)
-      );
-      setGameSchedule(res.gameSchedule ?? []);
-    } catch (error) {
-      console.error('경기 정보 조회 실패', error);
-      setGameSchedule([]);
-    }
-  };
-
-  fetchGameSchedule();
-}, [selectedDate]);
-
 
   return (
     <div className="pb-[5.6rem]">
@@ -87,7 +58,7 @@ useEffect(() => {
         isOpen={isGameInfoBottomSheetOpen}
         onClose={() => setIsGameInfoBottomSheetOpen(false)}
         date={format(selectedDate, 'yyyy-MM-dd')}
-        gameSchedule={gameSchedule}
+        gameSchedule={data}
         activeType={activeType}
       />
     </div>

--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -1,30 +1,62 @@
-import GameMatchBottomSheet from '@components/bottom-sheet/game-match/game-match-bottom-sheet';
-import { WEEK_CALENDAR_START_OFFSET } from '@components/calendar/constants/CALENDAR';
-import { getInitialSelectedDate } from '@components/calendar/utils/date-grid';
-import { useTabState } from '@hooks/use-tab-state';
-import { mockGameDatas } from '@mocks/mockGameData';
-import CalendarBottomSheet from '@pages/home/components/calendar-bottom-sheet';
+import { useEffect, useState } from 'react';
+import { format, addDays } from 'date-fns';
+
+import TopSection from '@pages/home/components/top-section';
 import CalendarSection from '@pages/home/components/calendar-section';
 import MatchListSection from '@pages/home/components/match-list-section';
-import TopSection from '@pages/home/components/top-section';
-import { addDays, format } from 'date-fns';
-import { useState } from 'react';
+import CalendarBottomSheet from '@pages/home/components/calendar-bottom-sheet';
+import GameMatchBottomSheet from '@components/bottom-sheet/game-match/game-match-bottom-sheet';
+
+import { useTabState } from '@hooks/use-tab-state';
+import { WEEK_CALENDAR_START_OFFSET } from '@components/calendar/constants/CALENDAR';
+import { getInitialSelectedDate } from '@components/calendar/utils/date-grid';
+import { get } from '@apis/base/http';
+import { END_POINT } from '@constants/api';
+import type { ApiResponse } from '@/shared/types/base-types';
+
+interface GameSchedule {
+  id: number;
+  awayTeam: string;
+  homeTeam: string;
+  gameTime: string;
+  stadium: string;
+}
 
 const Home = () => {
   const { activeType, changeTab, isSingle, isGroup } = useTabState();
   const entryDate = new Date();
   const initialSelectedDate = getInitialSelectedDate(entryDate);
+
   const [selectedDate, setSelectedDate] = useState(initialSelectedDate);
   const [baseWeekDate, setBaseWeekDate] = useState(
-    addDays(selectedDate, WEEK_CALENDAR_START_OFFSET),
+    addDays(initialSelectedDate, WEEK_CALENDAR_START_OFFSET)
   );
   const [isCalendarBottomSheetOpen, setIsCalendarBottomSheetOpen] = useState(false);
   const [isGameInfoBottomSheetOpen, setIsGameInfoBottomSheetOpen] = useState(false);
+  const [gameSchedule, setGameSchedule] = useState<GameSchedule[]>([]);
 
   const handleDateSelect = (date: Date) => {
     setSelectedDate(date);
     setBaseWeekDate(date);
   };
+
+useEffect(() => {
+  const fetchGameSchedule = async () => {
+    const dateStr = format(selectedDate, 'yyyy-MM-dd');
+    try {
+      const res = await get<ApiResponse<{ gameSchedule: GameSchedule[] }>>(
+        END_POINT.GET_GAME_SCHEDULE(dateStr)
+      );
+      setGameSchedule(res.gameSchedule ?? []);
+    } catch (error) {
+      console.error('경기 정보 조회 실패', error);
+      setGameSchedule([]);
+    }
+  };
+
+  fetchGameSchedule();
+}, [selectedDate]);
+
 
   return (
     <div className="pb-[5.6rem]">
@@ -55,7 +87,7 @@ const Home = () => {
         isOpen={isGameInfoBottomSheetOpen}
         onClose={() => setIsGameInfoBottomSheetOpen(false)}
         date={format(selectedDate, 'yyyy-MM-dd')}
-        gameSchedule={mockGameDatas}
+        gameSchedule={gameSchedule}
         activeType={activeType}
       />
     </div>

--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -1,3 +1,4 @@
+import { gameQueries } from '@apis/game/game-queries';
 import GameMatchBottomSheet from '@components/bottom-sheet/game-match/game-match-bottom-sheet';
 import { WEEK_CALENDAR_START_OFFSET } from '@components/calendar/constants/CALENDAR';
 import { getInitialSelectedDate } from '@components/calendar/utils/date-grid';
@@ -6,10 +7,9 @@ import CalendarBottomSheet from '@pages/home/components/calendar-bottom-sheet';
 import CalendarSection from '@pages/home/components/calendar-section';
 import MatchListSection from '@pages/home/components/match-list-section';
 import TopSection from '@pages/home/components/top-section';
+import { useQuery } from '@tanstack/react-query';
 import { addDays, format } from 'date-fns';
 import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { gameQueries } from '@apis/game/game-queries';
 
 const Home = () => {
   const { activeType, changeTab, isSingle, isGroup } = useTabState();

--- a/src/shared/apis/game/game-queries.ts
+++ b/src/shared/apis/game/game-queries.ts
@@ -7,9 +7,14 @@ import type { getGameScheduleResponse } from '@/shared/types/game-types';
 export const gameQueries = {
   ALL: () => queryOptions({ queryKey: GAME_KEY.ALL }),
 
-  GAME_LIST: () =>
-    queryOptions<getGameScheduleResponse>({
-      queryKey: GAME_KEY.SCHEDULE(),
-      queryFn: () => get(END_POINT.GET_GAME_SCHEDULE),
+  GAME_LIST: (dateStr: string) =>
+    queryOptions<getGameScheduleResponse['gameSchedule']>({
+      queryKey: GAME_KEY.SCHEDULE(dateStr),
+      queryFn: async () => {
+        const res = await get<getGameScheduleResponse>(
+          END_POINT.GET_GAME_SCHEDULE(dateStr),
+        );
+        return res.gameSchedule ?? [];
+      },
     }),
 };

--- a/src/shared/apis/game/game-queries.ts
+++ b/src/shared/apis/game/game-queries.ts
@@ -11,9 +11,7 @@ export const gameQueries = {
     queryOptions<getGameScheduleResponse['gameSchedule']>({
       queryKey: GAME_KEY.SCHEDULE(dateStr),
       queryFn: async () => {
-        const res = await get<getGameScheduleResponse>(
-          END_POINT.GET_GAME_SCHEDULE(dateStr),
-        );
+        const res = await get<getGameScheduleResponse>(END_POINT.GET_GAME_SCHEDULE(dateStr));
         return res.gameSchedule ?? [];
       },
     }),

--- a/src/shared/components/bottom-sheet/game-match/game-match-bottom-sheet.tsx
+++ b/src/shared/components/bottom-sheet/game-match/game-match-bottom-sheet.tsx
@@ -31,7 +31,6 @@ const GameMatchBottomSheet = ({
   activeType,
 }: GameMatchBottomSheetProps) => {
   const [selectedIdx, setSelectedIdx] = useState<number | null>(null);
-  const matchId = 1; //임시 설정용
   const navigate = useNavigate();
   const navigateToMatchCreate = (matchId: number, type: 'single' | 'group') => {
     navigate(`/match/create/${matchId}?type=${type}`);
@@ -51,9 +50,10 @@ const GameMatchBottomSheet = ({
     if (!selectedGame) return;
 
     const queryType = activeType === TAB_TYPES.SINGLE ? 'single' : 'group';
-    navigateToMatchCreate(matchId, queryType);
+    navigateToMatchCreate(selectedGame.id, queryType);
     handleClose();
   };
+
 
   return (
     <BottomSheet isOpen={isOpen} onClose={handleClose} showIndicator gap="gap-[1.6rem]">

--- a/src/shared/components/bottom-sheet/game-match/game-match-bottom-sheet.tsx
+++ b/src/shared/components/bottom-sheet/game-match/game-match-bottom-sheet.tsx
@@ -54,7 +54,6 @@ const GameMatchBottomSheet = ({
     handleClose();
   };
 
-
   return (
     <BottomSheet isOpen={isOpen} onClose={handleClose} showIndicator gap="gap-[1.6rem]">
       <div className="w-full flex-col">

--- a/src/shared/components/bottom-sheet/game-match/game-match-item.tsx
+++ b/src/shared/components/bottom-sheet/game-match/game-match-item.tsx
@@ -22,7 +22,7 @@ const GameMatchItem = ({ isSelected, away, home, time, stadium, onClick }: GameM
     >
       <div className="body_16_m flex-row gap-[0.4rem] text-gray-black">
         <span>{away}</span>
-        <span>VS</span>
+        <span>vs</span>
         <span>{home}</span>
       </div>
 

--- a/src/shared/constants/api.ts
+++ b/src/shared/constants/api.ts
@@ -11,7 +11,8 @@ export const END_POINT = {
   POST_INFO_NICKNAME: '/v1/users/info/nickname',
 
   // 경기 관련
-  GET_GAME_SCHEDULE: '/v1/users/game/schedule',
+  GET_GAME_SCHEDULE: (date: string) => `/v1/users/game/schedule?date=${date}`,
+
 
   // 매칭
   GET_USERS_NUM_COUNT: (matchId: number | string) => `/v1/users/num-count/${matchId}`,

--- a/src/shared/constants/api.ts
+++ b/src/shared/constants/api.ts
@@ -13,7 +13,6 @@ export const END_POINT = {
   // 경기 관련
   GET_GAME_SCHEDULE: (date: string) => `/v1/users/game/schedule?date=${date}`,
 
-
   // 매칭
   GET_USERS_NUM_COUNT: (matchId: number | string) => `/v1/users/num-count/${matchId}`,
   GET_SINGLE_RESULT: (matchId: number | string) => `/v1/users/direct/${matchId}`,

--- a/src/shared/constants/query-key.ts
+++ b/src/shared/constants/query-key.ts
@@ -14,10 +14,9 @@ export const AUTH_KEY = {
 
 // game domain
 export const GAME_KEY = {
-  ALL: ['game'] as const,
-
-  SCHEDULE: () => [...GAME_KEY.ALL, 'schedule'] as const,
-} as const;
+  ALL: ['game'],
+  SCHEDULE: (dateStr: string) => ['game', 'schedule', dateStr],
+};
 
 // match domain
 export const MATCH_KEY = {


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #178

## ☀️ New-insight

* `React Query`의 `queryKey`는 매개변수 기반으로 유니크하게 구성해야 날짜별 캐시 분리가 가능하다는 것을 배웠습니다.
* 기존에는 `GAME_KEY.SCHEDULE()`처럼 인자를 받지 않는 고정 키를 사용하여, 날짜가 바뀌어도 동일한 데이터가 유지되는 문제가 있었습니다.
* `GAME_KEY.SCHEDULE(dateStr)`로 동적으로 key를 구성해 캐싱을 정확하게 분리할 수 있음을 확인했습니다.

## 💎 PR Point

* `GAME_KEY.SCHEDULE`을 `dateStr`을 인자로 받는 형태로 리팩토링하여 날짜별 쿼리 캐시 분리가 가능하도록 수정했습니다.
* `gameQueries.GAME_LIST(dateStr)`에서도 해당 queryKey를 반영하여 쿼리가 정확히 갱신되도록 했습니다.
* 이를 통해 `Home.tsx`와 `GameMatchBottomSheet.tsx`에서 날짜를 선택할 때마다 정확한 데이터가 반영되며, 캐시와 서버 간의 데이터 불일치 문제가 해결되었습니다.

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 게임 일정 데이터를 실시간으로 불러오는 기능이 추가되었습니다.

* **버그 수정**
  * 경기 생성 시 고정된 matchId 대신 선택한 경기의 id를 사용하도록 개선되었습니다.

* **스타일**
  * 경기 항목에서 "VS" 표기가 소문자 "vs"로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->