### PR TITLE
fix: 매칭 현황 브라우저 뒤로가기 에러 해결

### DIFF
--- a/src/pages/result/components/matching-agree-view.tsx
+++ b/src/pages/result/components/matching-agree-view.tsx
@@ -8,7 +8,7 @@ import { useNavigate } from 'react-router-dom';
 
 const MatchingAgreeView = () => {
   const navigate = useNavigate();
-  usePreventBackNavigation('/match');
+  usePreventBackNavigation(ROUTES.MATCH);
 
   // TODO: 실제 매칭된 인원 상태에서 받아오기
   const matchedCount = 3;

--- a/src/pages/result/components/matching-agree-view.tsx
+++ b/src/pages/result/components/matching-agree-view.tsx
@@ -1,12 +1,14 @@
 import Button from '@components/button/button/button';
 import MatchCurrentCard from '@components/card/match-current-card/match-current-card';
 import { LOTTIE_PATH } from '@constants/lotties';
+import usePreventBackNavigation from '@hooks/use-prevent-back-navigation';
 import { ROUTES } from '@routes/routes-config';
 import { Lottie } from '@toss/lottie';
 import { useNavigate } from 'react-router-dom';
 
 const MatchingAgreeView = () => {
   const navigate = useNavigate();
+  usePreventBackNavigation('/match');
 
   // TODO: 실제 매칭된 인원 상태에서 받아오기
   const matchedCount = 3;

--- a/src/pages/result/components/matching-fail-view.tsx
+++ b/src/pages/result/components/matching-fail-view.tsx
@@ -1,11 +1,13 @@
 import Button from '@components/button/button/button';
 import { LOTTIE_PATH } from '@constants/lotties';
+import usePreventBackNavigation from '@hooks/use-prevent-back-navigation';
 import { ROUTES } from '@routes/routes-config';
 import { Lottie } from '@toss/lottie';
 import { useNavigate } from 'react-router-dom';
 
 const MatchingFailView = () => {
   const navigate = useNavigate();
+  usePreventBackNavigation('/match');
 
   return (
     <div className="h-full flex-col-between">

--- a/src/pages/result/components/matching-fail-view.tsx
+++ b/src/pages/result/components/matching-fail-view.tsx
@@ -7,7 +7,7 @@ import { useNavigate } from 'react-router-dom';
 
 const MatchingFailView = () => {
   const navigate = useNavigate();
-  usePreventBackNavigation('/match');
+  usePreventBackNavigation(ROUTES.MATCH);
 
   return (
     <div className="h-full flex-col-between">

--- a/src/pages/result/components/matching-receive-view.tsx
+++ b/src/pages/result/components/matching-receive-view.tsx
@@ -1,5 +1,6 @@
 import Button from '@components/button/button/button';
 import Card from '@components/card/match-card/card';
+import usePreventBackNavigation from '@hooks/use-prevent-back-navigation';
 import { mockMateReceive } from '@mocks/mockMatchReceiveData';
 import { MATCHING_HEADER_MESSAGE } from '@pages/result/constants/matching-result';
 import { ROUTES } from '@routes/routes-config';
@@ -11,6 +12,7 @@ interface MatchingReceiveViewProps {
 
 const MatchingReceiveView = ({ isGroupMatching = true }: MatchingReceiveViewProps) => {
   const navigate = useNavigate();
+  usePreventBackNavigation('/match');
 
   const handleReject = () => {
     navigate(`${ROUTES.RESULT}?type=fail`);

--- a/src/pages/result/components/matching-receive-view.tsx
+++ b/src/pages/result/components/matching-receive-view.tsx
@@ -12,7 +12,7 @@ interface MatchingReceiveViewProps {
 
 const MatchingReceiveView = ({ isGroupMatching = true }: MatchingReceiveViewProps) => {
   const navigate = useNavigate();
-  usePreventBackNavigation('/match');
+  usePreventBackNavigation(ROUTES.MATCH);
 
   const handleReject = () => {
     navigate(`${ROUTES.RESULT}?type=fail`);

--- a/src/pages/result/components/matching-success-view.tsx
+++ b/src/pages/result/components/matching-success-view.tsx
@@ -12,7 +12,7 @@ interface MatchingSuccessViewProps {
 
 const MatchingSuccessView = ({ isGroupMatching }: MatchingSuccessViewProps) => {
   const navigate = useNavigate();
-  usePreventBackNavigation('/match');
+  usePreventBackNavigation(ROUTES.MATCH);
 
   return (
     <div className="h-full flex-col-between">

--- a/src/pages/result/components/matching-success-view.tsx
+++ b/src/pages/result/components/matching-success-view.tsx
@@ -1,5 +1,6 @@
 import Button from '@components/button/button/button';
 import { LOTTIE_PATH } from '@constants/lotties';
+import usePreventBackNavigation from '@hooks/use-prevent-back-navigation';
 import { MATCHING_SUCCESS_TITLE } from '@pages/match/constants/matching';
 import { ROUTES } from '@routes/routes-config';
 import { Lottie } from '@toss/lottie';
@@ -11,6 +12,7 @@ interface MatchingSuccessViewProps {
 
 const MatchingSuccessView = ({ isGroupMatching }: MatchingSuccessViewProps) => {
   const navigate = useNavigate();
+  usePreventBackNavigation('/match');
 
   return (
     <div className="h-full flex-col-between">

--- a/src/pages/result/components/sent-view.tsx
+++ b/src/pages/result/components/sent-view.tsx
@@ -1,5 +1,6 @@
 import Button from '@components/button/button/button';
 import { LOTTIE_PATH } from '@constants/lotties';
+import usePreventBackNavigation from '@hooks/use-prevent-back-navigation';
 import { MATCHING_COMPLETE_MESSAGE } from '@pages/match/constants/matching';
 import { ROUTES } from '@routes/routes-config';
 import { Lottie } from '@toss/lottie';
@@ -10,6 +11,8 @@ interface SentViewProps {
 }
 
 const SentView = ({ isGroupMatching = true }: SentViewProps) => {
+  usePreventBackNavigation('/');
+
   const navigate = useNavigate();
   const handleGoHome = () => navigate(ROUTES.HOME);
   const handleGoMatch = () => navigate(ROUTES.MATCH);
@@ -27,7 +30,7 @@ const SentView = ({ isGroupMatching = true }: SentViewProps) => {
           진행 과정은 ‘매칭 현황'에서 확인할 수 있어요!
         </p>
       </section>
-      <div className="flex-row-center gap-[0.8rem] p-[1.6rem]">
+      <div className="w-full flex-row-center gap-[0.8rem] p-[1.6rem]">
         <Button label="메이트 더 찾아보기" variant="skyblue" onClick={handleGoHome} />
         <Button label="매칭 현황 보기" onClick={handleGoMatch} />
       </div>

--- a/src/pages/result/components/sent-view.tsx
+++ b/src/pages/result/components/sent-view.tsx
@@ -11,7 +11,7 @@ interface SentViewProps {
 }
 
 const SentView = ({ isGroupMatching = true }: SentViewProps) => {
-  usePreventBackNavigation('/');
+  usePreventBackNavigation(ROUTES.HOME);
 
   const navigate = useNavigate();
   const handleGoHome = () => navigate(ROUTES.HOME);

--- a/src/shared/hooks/use-prevent-back-navigation.ts
+++ b/src/shared/hooks/use-prevent-back-navigation.ts
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+
+const usePreventBackNavigation = (redirectUrl?: string) => {
+  useEffect(() => {
+    const handlePopState = () => {
+      window.history.pushState(null, '', window.location.href);
+
+      if (redirectUrl) {
+        window.location.href = redirectUrl;
+      }
+    };
+
+    window.history.pushState(null, '', window.location.href);
+    window.addEventListener('popstate', handlePopState);
+
+    return () => {
+      window.removeEventListener('popstate', handlePopState);
+    };
+  }, [redirectUrl]);
+};
+
+export default usePreventBackNavigation;

--- a/src/shared/hooks/use-prevent-back-navigation.ts
+++ b/src/shared/hooks/use-prevent-back-navigation.ts
@@ -1,12 +1,15 @@
 import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 const usePreventBackNavigation = (redirectUrl?: string) => {
+  const navigate = useNavigate();
+
   useEffect(() => {
     const handlePopState = () => {
       window.history.pushState(null, '', window.location.href);
 
       if (redirectUrl) {
-        window.location.href = redirectUrl;
+        navigate(redirectUrl, { replace: true });
       }
     };
 
@@ -16,7 +19,7 @@ const usePreventBackNavigation = (redirectUrl?: string) => {
     return () => {
       window.removeEventListener('popstate', handlePopState);
     };
-  }, [redirectUrl]);
+  }, [redirectUrl, navigate]);
 };
 
 export default usePreventBackNavigation;

--- a/src/shared/hooks/use-prevent-back-navigation.ts
+++ b/src/shared/hooks/use-prevent-back-navigation.ts
@@ -1,16 +1,12 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-const usePreventBackNavigation = (redirectUrl?: string) => {
+const usePreventBackNavigation = (redirectUrl: string) => {
   const navigate = useNavigate();
 
   useEffect(() => {
     const handlePopState = () => {
-      window.history.pushState(null, '', window.location.href);
-
-      if (redirectUrl) {
-        navigate(redirectUrl, { replace: true });
-      }
+      navigate(redirectUrl, { replace: true });
     };
 
     window.history.pushState(null, '', window.location.href);
@@ -19,7 +15,7 @@ const usePreventBackNavigation = (redirectUrl?: string) => {
     return () => {
       window.removeEventListener('popstate', handlePopState);
     };
-  }, [redirectUrl, navigate]);
+  }, [navigate, redirectUrl]);
 };
 
 export default usePreventBackNavigation;


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #189

## ☀️ New-insight

* 브라우저의 `popstate` 이벤트는 사용자가 뒤로가기를 누를 때 발생하며, 이를 통해 뒤로가기를 제어할 수 있다는 점을 알게 되었습니다.
* 히스토리 스택을 조작하여 사용자가 의도치 않게 이전 페이지로 이동하는 것을 방지할 수 있습니다.

## 💎 PR Point

### `usePreventBackNavigation` 훅
`usePreventBackNavigation`은 사용자가 브라우저의 '뒤로가기' 버튼을 클릭할 때 원치 않는 페이지 이동을 막거나, 특정 페이지(`/home`, `ROUTES.MATCH` 등)로 강제 이동시킬 수 있는 커스텀 훅입니다.
[https://developer.mozilla.org/ko/docs/Web/API/History/pushState](url)
* `usePreventBackNavigation` 커스텀 훅을 생성하여 뒤로가기 시 전달된 `redirectUrl`로 이동할 수 있도록 처리했습니다.




## 코드 전체 흐름 요약

```tsx
const usePreventBackNavigation = (redirectUrl: string) => {
```

* `redirectUrl`: 뒤로가기 눌렀을 때 이동할 경로 (`/home`, `/match` 등)

```tsx
const navigate = useNavigate();
```

* `react-router-dom`에서 `navigate()`를 가져옴
* 페이지 이동을 JS 코드로 수행할 수 있게 함

## 핵심 로직 (useEffect 안)

```tsx
useEffect(() => {
```

* 컴포넌트가 마운트될 때만 실행됨


### 1. 뒤로가기 감지 핸들러 등록

```tsx
const handlePopState = () => {
  navigate(redirectUrl, { replace: true });
};
```

* 사용자가 **뒤로가기 버튼을 누르면 popstate 이벤트가 발생**
* `navigate()`로 **지정한 URL로 이동**


### 2. 현재 URL을 pushState로 강제로 스택에 추가

```tsx
window.history.pushState(null, '', window.location.href);
```

* 현재 주소를 브라우저 히스토리 스택에 다시 넣어줌
* 이렇게 하면, 브라우저가 “뒤로 가도 다시 지금 페이지”를 보려고 함
  → 그 순간 우리가 감지해서 `redirectUrl`로 이동시킴


### 3. 이벤트 리스너 등록 & 정리

```tsx
window.addEventListener('popstate', handlePopState);
return () => {
  window.removeEventListener('popstate', handlePopState);
};
```

* 뒤로가기를 감지하는 이벤트 등록
* 컴포넌트가 언마운트될 때 이벤트 제거해서 메모리 누수 방지


### 결과적으로 어떤 일이 발생하는가..

1. 페이지에 진입하면 **현재 URL을 히스토리에 한 번 더 쌓고**
2. 뒤로가기 버튼을 누르면
3. **`popstate` 이벤트가 발생하고**, 우리는 바로 `navigate(redirectUrl)`를 호출합니다.
4. 사용자는 결국 **뒤로 가지 않고, 우리가 지정한 URL로 강제 이동**합니다.



### 예시 사용

```tsx
usePreventBackNavigation('/match');
```

→ 뒤로가기 누르면 무조건 `/match`로 이동합니다.


### 사용법

```ts
usePreventBackNavigation(); // 현재 페이지에 고정
usePreventBackNavigation('/home'); // 뒤로가기 시 /home으로 이동
```

### 사용하는 상황
* 온보딩 도중 뒤로가기 누르면 홈으로 이동시키고 싶을 때
* 특정 결과 페이지에서 사용자가 임의로 이전 단계로 돌아가지 못하게 막을 때


* 필요 시 특정 페이지에만 조건부 적용 가능합니다.
* 다음 작업으로 뒤로가기 후에도 1:1/그룹 탭 상태 유지하는 거 해야 합니다!!
(현재 상태에서는 사용자가 URL `/match`에서 '1:1' 탭을 보고 있다가 다른 페이지로 이동한 뒤 다시 '뒤로가기'를 누르면, 탭 상태가 초기값인 `'1:1'`로 되돌아가거나 **초기 상태(`useState('1:1')`)** 로 리셋됩니다.)


## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 특정 결과 화면에서 뒤로 가기(Back Navigation)를 방지하는 기능이 추가되었습니다. 이제 해당 화면에서 이전 페이지로 돌아갈 수 없습니다.
  * SentView 화면 하단 버튼 컨테이너가 전체 너비로 표시되도록 스타일이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->