### PR TITLE
feat: 1:1 매칭 리스트 조회 api 연결

### DIFF
--- a/src/pages/home/components/match-list-section.tsx
+++ b/src/pages/home/components/match-list-section.tsx
@@ -1,10 +1,11 @@
+import { matchQueries } from '@apis/match/match-queries';
 import ButtonCreate from '@components/button/button-create/button-create';
 import type { TabType } from '@components/tab/tab/constants/tab-type';
 import EmptyState from '@components/ui/empty-state';
 import { mockMateGroup } from '@mocks/mockMateGroup';
-import { mockMateSingle } from '@mocks/mockMateSingle';
 import { renderMatchCards } from '@pages/home/utils/match-card-renderers';
 import { ROUTES } from '@routes/routes-config';
+import { useQuery } from '@tanstack/react-query';
 import { format } from 'date-fns';
 import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -23,12 +24,17 @@ const MatchListSection = ({
   onOpenGameInfoBottomSheet,
 }: MatchListSectionProps) => {
   const navigate = useNavigate();
+  const formattedDate = format(selectedDate, 'yyyy-MM-dd');
+
+  const { data: singleMatchData } = useQuery({
+    ...matchQueries.SINGLE_MATCH_LIST(formattedDate),
+    enabled: isSingle,
+  });
 
   const filteredMatches = useMemo(() => {
-    const formattedDate = format(selectedDate, 'yyyy-MM-dd');
-    const sourceData = isSingle ? mockMateSingle : mockMateGroup;
-    return sourceData.filter((match) => match.date === formattedDate);
-  }, [selectedDate, isSingle]);
+    if (isSingle) return singleMatchData?.mates ?? [];
+    return mockMateGroup.filter((match) => match.date === formattedDate);
+  }, [isSingle, singleMatchData, formattedDate]);
 
   const handleCardClick = (matchId: number) => {
     if (isSingle) {

--- a/src/pages/home/components/match-list-section.tsx
+++ b/src/pages/home/components/match-list-section.tsx
@@ -32,8 +32,9 @@ const MatchListSection = ({
   });
 
   const filteredMatches = useMemo(() => {
-    if (isSingle) return singleMatchData?.mates ?? [];
-    return mockMateGroup.filter((match) => match.date === formattedDate);
+    return isSingle
+      ? (singleMatchData?.mates ?? [])
+      : mockMateGroup.filter((match) => match.date === formattedDate);
   }, [isSingle, singleMatchData, formattedDate]);
 
   const handleCardClick = (matchId: number) => {


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #191 

## ☀️ New-insight

1:1 매칭 리스트 조회 api를 연결했습니다.

## 💎 PR Point

- `enabled: false`로 `isSingle`일 때만 쿼리가 실행되도록 했습니다.
- 그룹 매칭 리스트 조회는 다음 pr에서 작성할 예정이라 아직 목데이터입니다.

## 📸 Screenshot

<img width="1578" height="1103" alt="스크린샷 2025-07-16 오전 5 35 09" src="https://github.com/user-attachments/assets/0ccdd6eb-e851-4e96-912d-3791f5a2d5af" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 싱글 매치 데이터가 이제 실시간으로 조회되어 최신 정보를 제공합니다.

* **개선 사항**
  * 그룹 매치는 기존과 동일하게 동작하며, 싱글 매치에 한해 동적 데이터가 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->