### PR TITLE
feat: 매칭된 인원 조회 api를 연결합니다.

### DIFF
--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -44,7 +44,7 @@ const Home = () => {
   };
 
   return (
-    <div className="bg-gray-200 pb-[5.6rem]">
+    <div className=" bg-gray-200 pb-[5.6rem]">
       <TopSection />
       <CalendarSection
         activeType={activeType}

--- a/src/pages/result/components/matching-agree-view.tsx
+++ b/src/pages/result/components/matching-agree-view.tsx
@@ -3,7 +3,7 @@ import Button from '@components/button/button/button';
 import MatchCurrentCard from '@components/card/match-current-card/match-current-card';
 import { LOTTIE_PATH } from '@constants/lotties';
 import { ROUTES } from '@routes/routes-config';
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { Lottie } from '@toss/lottie';
 import { useNavigate } from 'react-router-dom';
 
@@ -14,8 +14,7 @@ interface MatchingAgreeViewProps {
 const MatchingAgreeView = ({ matchId }: MatchingAgreeViewProps) => {
   const navigate = useNavigate();
 
-  const { data: agreeData } = useQuery(matchQueries.COUNTED_MEMBER(Number(matchId)));
-
+  const { data: agreeData } = useSuspenseQuery(matchQueries.COUNTED_MEMBER(Number(matchId)));
   const matchedCount = agreeData?.count;
 
   return (

--- a/src/pages/result/components/matching-agree-view.tsx
+++ b/src/pages/result/components/matching-agree-view.tsx
@@ -1,15 +1,22 @@
+import { matchQueries } from '@apis/match/match-queries';
 import Button from '@components/button/button/button';
 import MatchCurrentCard from '@components/card/match-current-card/match-current-card';
 import { LOTTIE_PATH } from '@constants/lotties';
 import { ROUTES } from '@routes/routes-config';
+import { useQuery } from '@tanstack/react-query';
 import { Lottie } from '@toss/lottie';
 import { useNavigate } from 'react-router-dom';
 
-const MatchingAgreeView = () => {
+interface MatchingAgreeViewProps {
+  matchId: string;
+}
+
+const MatchingAgreeView = ({ matchId }: MatchingAgreeViewProps) => {
   const navigate = useNavigate();
 
-  // TODO: 실제 매칭된 인원 상태에서 받아오기
-  const matchedCount = 3;
+  const { data: agreeData } = useQuery(matchQueries.COUNTED_MEMBER(Number(matchId)));
+
+  const matchedCount = agreeData?.count;
 
   return (
     <div className="h-full flex-col-between gap-[2.4rem] px-[1.6rem]">

--- a/src/pages/result/components/matching-success-view.tsx
+++ b/src/pages/result/components/matching-success-view.tsx
@@ -30,7 +30,6 @@ const MatchingSuccessView = ({ isGroupMatching }: MatchingSuccessViewProps) => {
         </p>
       </div>
       <div className="w-full flex-row-center gap-[0.8rem] p-[1.6rem]">
-        {/* TODO: onClick 로직 수정 */}
         <Button label="채팅방 입장하기" className="w-full" onClick={() => navigate(ROUTES.CHAT)} />
       </div>
     </div>

--- a/src/pages/result/result.tsx
+++ b/src/pages/result/result.tsx
@@ -1,16 +1,23 @@
+import ErrorView from '@pages/error/error-view';
 import MatchingAgreeView from '@pages/result/components/matching-agree-view';
 import MatchingFailView from '@pages/result/components/matching-fail-view';
 import MatchingReceiveView from '@pages/result/components/matching-receive-view';
 import MatchingSuccessView from '@pages/result/components/matching-success-view';
 import SentView from '@pages/result/components/sent-view';
 import { ROUTES } from '@routes/routes-config';
-import { Navigate, useSearchParams } from 'react-router-dom';
+import { Navigate, useParams, useSearchParams } from 'react-router-dom';
 
 const ResultPage = () => {
+  const { matchId } = useParams();
   const [params] = useSearchParams();
+
   const type = params.get('type');
   const mode = params.get('mode');
-  const isGroupMatching = mode?.toLowerCase() === 'group';
+  const isGroupMatching = mode === 'group';
+
+  if (!type || !matchId) {
+    return <ErrorView />;
+  }
 
   if (type === 'sent') {
     return <SentView isGroupMatching={isGroupMatching} />;
@@ -21,7 +28,7 @@ const ResultPage = () => {
   }
 
   if (type === 'agree') {
-    return <MatchingAgreeView />;
+    return <MatchingAgreeView matchId={matchId} />;
   }
 
   if (type === 'fail') {

--- a/src/shared/components/card/match-current-card/match-current-card.tsx
+++ b/src/shared/components/card/match-current-card/match-current-card.tsx
@@ -1,7 +1,7 @@
 import { GROUP_MAX } from '@components/card/constants/MATCH';
 
 interface MatchCurrentCardProps {
-  count: number;
+  count?: number;
 }
 
 const MatchCurrentCard = ({ count }: MatchCurrentCardProps) => {

--- a/src/shared/components/header/utils/get-header.tsx
+++ b/src/shared/components/header/utils/get-header.tsx
@@ -16,7 +16,7 @@ export const getHeaderContent = (
     const type = urlParams.get('type') ?? '';
     const goMatchTypes = ['fail', 'agree', 'success', 'receive'];
 
-    if (pathname === ROUTES.RESULT) {
+    if (pathname === ROUTES.RESULT()) {
       if (type === 'sent') {
         navigate(ROUTES.HOME);
         return;

--- a/src/shared/routes/layout.tsx
+++ b/src/shared/routes/layout.tsx
@@ -10,7 +10,7 @@ const Layout = () => {
   const { pathname, search } = useLocation();
   const params = new URLSearchParams(search);
 
-  const isFail = pathname === ROUTES.RESULT && params.get('type') === 'fail';
+  const isFail = pathname === ROUTES.RESULT() && params.get('type') === 'fail';
 
   const showBottomNav = SHOW_BOTTOM_NAVIGATE_PATHS.includes(pathname);
   const showHeader = !NO_HEADER_PATHS.includes(pathname);

--- a/src/shared/routes/protected-routes.tsx
+++ b/src/shared/routes/protected-routes.tsx
@@ -26,7 +26,7 @@ export const protectedRoutes = [
   { path: ROUTES.PROFILE_EDIT, element: <EditProfile /> },
   { path: ROUTES.CHAT, element: <ChatList /> },
   { path: ROUTES.CHAT_ROOM(), element: <ChatRoom /> },
-  { path: ROUTES.RESULT, element: <Result /> },
+  { path: ROUTES.RESULT(), element: <Result /> },
   { path: ROUTES.ONBOARDING, element: <Onboarding /> },
   { path: ROUTES.ONBOARDING_GROUP, element: <OnboardingGroup /> },
 ];

--- a/src/shared/routes/routes-config.ts
+++ b/src/shared/routes/routes-config.ts
@@ -15,7 +15,7 @@ export const ROUTES = {
   PROFILE_EDIT: '/profile/edit',
   CHAT: '/chat',
   CHAT_ROOM: (id = ':matchId') => `/chat/${id}`,
-  RESULT: '/result',
+  RESULT: (id = ':matchId') => `/result/${id}`,
   ERROR: '/error',
   LOADING: '/loading',
   SPLASH: '/splash',


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #203 

## ☀️ New-insight
- 매칭된 인원 조회 api (그룹 요청을 보내고, 내가 승인되어 그 그룹의 멤버로 권한이 바뀌었을 때 화면) 연결했습니다.

## 💎 PR Point
- 다시보니 layout.tsx에 style이 main 위에 div를 한번 더 감싸는 구조로 되어있어서 다른 페이지에서 불필요하게 h-svh 옵션이 들어가고 있는 것 같아요. 다른 페이지에 전체 레이아웃이 꼬여있어서 .... 모두 연동 작업 끝나면 다시 스타일 손봐야할 것 같습니다. ㅠㅠ
- result 경로가 동적 value를 받는 구조가 아니여서 수정했어요. protectedRoute 및 layout에도 수정해 놓았습니다.
- 매칭된 인원 조회 화면의 경우 group에서만 사용하는 화면이라 group mode일때 값이 필요하지 않아서 우선 경로를
- `/result/${matchId}?type=agree` 로 잡아 두었는데 후에 다른 결과 화면 작업하시는분들은 - `/result/${matchId}?type=agree&mode=single` 이렇게 뒤에 mode를 추가해서 분기처리 하시면 될 것 같습니다.
- 마찬가지로 로딩이 좀 들어가는데 초기에, 여기서 로딩 화면을 보여주면 사용자 경험을 방해하는 것 같아 suspenseQuery를 사용했습니다.

```
RESULT: (id = ':matchId') => `/result/${id}`,

// matching-agree-view.tsx
  const { data: agreeData } = useSuspenseQuery(matchQueries.COUNTED_MEMBER(Number(matchId)));
  const matchedCount = agreeData?.count;
```
## 📸 Screenshot

<center>
<img width="343" height="782" alt="image" src="https://github.com/user-attachments/assets/392055a9-6fe8-4910-be92-8affc255ea3a" />
</center>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 결과 페이지에서 URL의 matchId 파라미터를 인식하여 동적으로 처리합니다.
  * MatchingAgreeView 컴포넌트가 matchId를 받아 실시간 매칭 인원 수를 표시합니다.

* **버그 수정**
  * type 또는 matchId가 누락된 경우 오류 화면이 표시됩니다.

* **개선 사항**
  * 결과 관련 라우트가 동적 파라미터(matchId)를 지원하도록 구조가 변경되었습니다.
  * 일부 컴포넌트의 props가 선택적으로 변경되어 유연성이 향상되었습니다.

* **기타**
  * 불필요한 주석이 제거되었습니다.
  * 내부 라우트 및 경로 비교 방식이 함수 호출 방식으로 일관성 있게 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->