### PR TITLE
refactor: 홈 경기조회 api enabled 옵션 추가 

### DIFF
--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -33,7 +33,7 @@ const Home = () => {
   const dateStr = format(selectedDate, 'yyyy-MM-dd');
   const { data } = useQuery({
     ...gameQueries.GAME_LIST(dateStr),
-    enabled: isCalendarBottomSheetOpen,
+    enabled: isCalendarBottomSheetOpen || isGameInfoBottomSheetOpen,
   });
 
   const { needsMatchingSetup } = useAuth();

--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -31,7 +31,11 @@ const Home = () => {
   const [isGameInfoBottomSheetOpen, setIsGameInfoBottomSheetOpen] = useState(false);
 
   const dateStr = format(selectedDate, 'yyyy-MM-dd');
-  const { data } = useQuery(gameQueries.GAME_LIST(dateStr));
+  const { data } = useQuery({
+    ...gameQueries.GAME_LIST(dateStr),
+    enabled: isCalendarBottomSheetOpen,
+  });
+
   const { needsMatchingSetup } = useAuth();
 
   const handleDateSelect = (date: Date) => {

--- a/src/shared/components/header/header.tsx
+++ b/src/shared/components/header/header.tsx
@@ -7,6 +7,7 @@ const Header = () => {
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const urlParams = new URLSearchParams(location.search);
+
   const isFail = urlParams.get('type') === 'fail';
   const isSignUp = pathname.includes(ROUTES.SIGNUP);
   const isHome = pathname === ROUTES.HOME;


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #207 

## ☀️ New-insight
- NetWork 탭에서 불필요하게 호출되는 API 요청을 확인하고, 해당 컴포넌트에서 enabled 옵션이나 조건부 로직을 사용해 API가 필요한 시점에만 호출되도록 개선하자 !

## 💎 PR Point
- 이전 홈에서 주간 캘린더의 날짜를 클릭할때 마다 경기정보 (kbo에서 크롤링해오는 정보)가 계속해서 network탭에 response가 오는것을 확인할 수 있었습니다. 
<img width="459" height="435" alt="image" src="https://github.com/user-attachments/assets/a1dea326-9fde-40e2-a7f9-99b3c791b55e" />

- 실제 캘린더 아이콘이나, 맞춤매칭 생성하기를 눌러야지만 실제로 그 정보를 사용하는데, 사용하기 전 홈화면에서 계속해서 정보를 불러오는 것은 불필요하다고 판단해, gameQueries의 GAMELIST훅에 캘린더버튼이 클릭되었을때, 맞춤매칭생성하기 버튼을 눌러서 바텀시트가 올라왔을때만 정보를 연동해오도록 아래와 같은 enabled 옵션을 추가했습니다.
```ts
  const { data } = useQuery({ ..gameQueries.GAME_LIST(dateStr),
    enabled: isCalendarBottomSheetOpen || isGameInfoBottomSheetOpen,
  });
```

### NetWork탭을보고 필요하지 않은 곳에서 쓰이는 api 연동 내역은 옵션을 걸어서 지울 수 있도록 하자 !

## 📸 Screenshot

이후 홈에서 캘린더를 클릭해또, schedulr=....의 내역이 뜨지않습니다.
<img width="454" height="452" alt="image" src="https://github.com/user-attachments/assets/7df991c0-943d-401e-919c-bd29f6f11d21" />

바텀시트가 열릴때만 불러와집니다.
<img width="416" height="394" alt="image" src="https://github.com/user-attachments/assets/c62e1358-f0b2-48c9-a0a2-e50907b32dd1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 게임 목록 데이터가 불필요하게 반복 조회되는 현상을 방지하여, 캘린더 또는 게임 정보 화면이 열려 있을 때만 데이터가 조회되도록 개선되었습니다.

* **스타일**
  * 헤더 컴포넌트 내 코드 가독성을 위한 공백이 추가되었습니다. (기능에는 영향 없음)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->