### PR TITLE
feat: 매칭 요청 수락 api 연결 

### DIFF
--- a/src/pages/match/components/match-tab-pannel.tsx
+++ b/src/pages/match/components/match-tab-pannel.tsx
@@ -23,7 +23,7 @@ const MatchTabPanel = ({ cards, filter }: MatchTabPanelProps) => {
   const handleCardClick = (card: MatchableCardProps) => {
     const query = CLICKABLE_STATUS_MAP[card.status ?? ''];
     if (query) {
-      navigate(`${ROUTES.RESULT(card.id.toString())}?type=${query}&cardType=${card.type}`);
+      navigate(`${ROUTES.RESULT(card.id.toString())}?type=${query}&cardtype=${card.type}`);
     }
   };
 

--- a/src/pages/match/components/match-tab-pannel.tsx
+++ b/src/pages/match/components/match-tab-pannel.tsx
@@ -23,7 +23,7 @@ const MatchTabPanel = ({ cards, filter }: MatchTabPanelProps) => {
   const handleCardClick = (card: MatchableCardProps) => {
     const query = CLICKABLE_STATUS_MAP[card.status ?? ''];
     if (query) {
-      navigate(`${ROUTES.RESULT}?type=${query}`);
+      navigate(`${ROUTES.RESULT(card.id.toString())}?type=${query}&cardType=${card.type}`);
     }
   };
 

--- a/src/pages/match/match.tsx
+++ b/src/pages/match/match.tsx
@@ -43,9 +43,7 @@ const Match = () => {
   }));
 
   const contentMap = {
-    '1:1': (
-      <MatchTabPanel key="single" cards={singleCards} filter={filter} />
-    ),
+    '1:1': <MatchTabPanel key="single" cards={singleCards} filter={filter} />,
     그룹: <MatchTabPanel key="group" cards={groupCards} filter={filter} />,
   };
 

--- a/src/pages/match/match.tsx
+++ b/src/pages/match/match.tsx
@@ -43,7 +43,9 @@ const Match = () => {
   }));
 
   const contentMap = {
-    '1:1': <MatchTabPanel key="single" cards={singleCards} filter={filter} />,
+    '1:1': (
+      <MatchTabPanel key="single" cards={singleCards} filter={filter} />
+    ),
     그룹: <MatchTabPanel key="group" cards={groupCards} filter={filter} />,
   };
 

--- a/src/pages/result/components/matching-receive-view.tsx
+++ b/src/pages/result/components/matching-receive-view.tsx
@@ -37,6 +37,7 @@ const MatchingReceiveView = ({ isGroupMatching = true }: MatchingReceiveViewProp
       },
       onError: (error) => {
         console.error('매칭 수락 실패:', error);
+        navigate(ROUTES.ERROR);
       },
     });
   };

--- a/src/pages/result/components/matching-receive-view.tsx
+++ b/src/pages/result/components/matching-receive-view.tsx
@@ -16,7 +16,7 @@ const MatchingReceiveView = ({ isGroupMatching = true }: MatchingReceiveViewProp
   const navigate = useNavigate();
   const { matchId } = useParams();
   const [params] = useSearchParams();
-  const cardType = params.get('cardType');
+  const cardType = params.get('cardtype');
 
   usePreventBackNavigation(ROUTES.MATCH);
 


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #213

## ☀️ New-insight

<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->

## 💎 PR Point

<!-- 트러블 슈팅, 깊게 고민한 로직 설명, 공통 컴포넌트일 경우 사용방법 등을 적어주세요!  -->

- 요청 수락 api 연동했습니다.
- 요청 수락 버튼 클릭 시, 일대일인지 그룹인지에 따라 이동하는 페이지가 다르기 때문에 타입 구분이 가능하게 cardtype 파라미터를 붙였습니다.(일대일이면 요청 수락 시 /result?type=success, 그룹 요청 시 /result?type=agree으로 페이지 이동합니다.)

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 매치 수락 시, 매치 ID와 카드 타입에 따라 결과 페이지로 이동하는 동작이 개선되었습니다.
  * 매치 수락/거절 시 더 상세한 URL 경로 및 쿼리 파라미터가 적용됩니다.
  * 카드 클릭 시, 동적 경로와 추가 쿼리 파라미터를 포함한 상세한 네비게이션이 적용됩니다.

* **버그 수정**
  * 매치 수락 처리 중 오류 발생 시 알림이 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->