### PR TITLE
refactor: 최초매칭조건 설정 후 auth 쿼리 무효화

### DIFF
--- a/src/pages/onboarding/utils/onboarding-button.ts
+++ b/src/pages/onboarding/utils/onboarding-button.ts
@@ -1,3 +1,5 @@
+import { authQueries } from '@apis/auth/auth';
+import queryClient from '@libs/query-client';
 import { ROUTES } from '@routes/routes-config';
 import type { NavigateFunction } from 'react-router-dom';
 
@@ -55,6 +57,7 @@ export const handleButtonClick = (
         },
         {
           onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: authQueries.USER_STATUS().queryKey });
             if (selections.MATCHING_TYPE === '1:1 매칭') {
               goNext();
             } else {


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #240 

## ☀️ New-insight

온보딩 API 연동 후 use-auth 훅에서 condition 값이 바로 갱신되지 않아, 마이페이지 접근 시 조건이 바로 반영되지 않는 문제가 있었어요. 

## 💎 PR Point

온보딩 API를 제출할 때 authQuery를 invalidateQueries로 무효화해서 값을 업데이트했어요. 

## 📸 Screenshot

<img width="1313" height="1105" alt="스크린샷 2025-07-18 오전 5 23 52" src="https://github.com/user-attachments/assets/d9ee70d0-35db-43c3-ae88-4cbb6a9d136e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 온보딩 과정에서 매칭 단계 완료 시 사용자 상태 정보가 자동으로 새로고침되어 최신 상태가 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->