### PR TITLE
feat: 그룹 매칭 요청 api 연동

### DIFF
--- a/src/pages/match/groups/mates.tsx
+++ b/src/pages/match/groups/mates.tsx
@@ -29,6 +29,7 @@ const MatesPage = () => {
           description={MATCHING_DESCRIPTION.group.description}
           subDescription={MATCHING_DESCRIPTION.group.subDescription}
           isGroupMatching={true}
+          matchId={numericMatchId}
         />
       )}
     </>

--- a/src/shared/components/bottom-sheet/bottom-sheet-modal.tsx
+++ b/src/shared/components/bottom-sheet/bottom-sheet-modal.tsx
@@ -34,7 +34,7 @@ const BottomSheetModal = ({
     requestMatch(matchId, {
       onSuccess: () => {
         const mode = isGroupMatching ? 'group' : 'single';
-        navigate(`${ROUTES.RESULT}?type=sent&mode=${mode}`);
+        navigate(`${ROUTES.RESULT(`${matchId}`)}?type=sent&mode=${mode}`);
         onClose();
       },
       onError: (error: unknown) => {


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #249 

## ☀️ New-insight

- 매칭 요청 후 페이지 이동 안 되었고, 1:1 매칭 요청 api만 연결되어 있었습니다,,ㅎ

## 💎 PR Point

- 1:1 매칭 요청 시 페이지 이동 및 api 연결 된 것 확인했습니다.
- 토스트 뜨는 것 확인했습니다.

## 📸 Screenshot

<img width="1377" height="1105" alt="스크린샷 2025-07-18 오전 6 23 04" src="https://github.com/user-attachments/assets/032d4222-3e6b-4347-ab0c-75778ec904d1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 모달 컴포넌트에 matchId가 전달되어 매치 관련 정보 표시가 개선되었습니다.

* **버그 수정**
  * 매치 요청 성공 시 이동하는 결과 페이지의 URL 구조가 변경되어, matchId가 경로에 직접 포함되도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->