### PR TITLE
fix: (QA/2) 홈 탭 마진 조정, 요청 거절 페이지 폰트 색 수정

### DIFF
--- a/src/pages/home/components/calendar-section.tsx
+++ b/src/pages/home/components/calendar-section.tsx
@@ -33,7 +33,7 @@ const CalendarSection = ({
           onDateChange(date);
         }}
       />
-      <section className="mt-[3.5rem] flex justify-between">
+      <section className="mt-[2.5rem] flex justify-between">
         <TabList colorMode="home" activeType={activeType} onTabChange={handleTabChange} />
         <CalendarButton onOpenBottomSheet={onOpenBottomSheet} />
       </section>

--- a/src/pages/result/components/matching-fail-view.tsx
+++ b/src/pages/result/components/matching-fail-view.tsx
@@ -1,6 +1,7 @@
 import Button from '@components/button/button/button';
 import { LOTTIE_PATH } from '@constants/lotties';
 import usePreventBackNavigation from '@hooks/use-prevent-back-navigation';
+import { MATCHING_GUIDE_MESSAGE_DESCRIPTION } from '@pages/match/constants/matching';
 import { ROUTES } from '@routes/routes-config';
 import { Lottie } from '@toss/lottie';
 import { useNavigate } from 'react-router-dom';
@@ -16,9 +17,8 @@ const MatchingFailView = () => {
         <div className="h-[16rem] w-[16rem] flex-row-center">
           <Lottie src={LOTTIE_PATH.FAIL} loop={true} className="w-[16rem]" />
         </div>
-        <p className="body_16_m text-center text-gray-600">
-          딱! 맞는 메이트의 요청이 도착하면 <br />
-          ‘매칭 현황’에서 확인할 수 있어요.
+        <p className="body_16_m whitespace-pre-line text-center text-gray-white">
+          {MATCHING_GUIDE_MESSAGE_DESCRIPTION}
         </p>
       </section>
       <section className="w-full flex-row-center gap-[0.8rem] p-[1.6rem]">


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #256 

## 💎 PR Point

- 홈에서 캘린더랑 탭 사이 마진 간격 3.5rem에서 2.5rem으로 수정했습니다.
- 요청 거절 페이지 폰트 색상 white로 수정 및 상수화했습니다.

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 홈 화면에서 캘린더와 탭/버튼 사이의 세로 간격이 줄어들었습니다.
  * 매칭 실패 안내 메시지의 색상과 줄바꿈 스타일이 변경되었습니다.

* **Bug Fixes**
  * 매칭 실패 안내 메시지가 동적으로 업데이트되어 더 정확한 안내가 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->