### PR TITLE
fix: (QA/1) 회원가입 화면 디자인 QA 반영

### DIFF
--- a/src/pages/sign-up/components/signup-step.tsx
+++ b/src/pages/sign-up/components/signup-step.tsx
@@ -117,17 +117,17 @@ const SignupStep = () => {
             <p className="body_16_m">성별</p>
             <div className="flex w-full gap-[0.8rem]">
               <Button
-                variant={genderValue === '여성' ? 'skyblueBorder' : 'white'}
+                variant={genderValue === '여성' ? 'skyblueBorder' : 'gray2'}
                 label="여성"
                 icon="female"
-                className="flex w-full gap-[0.4rem] bg-background"
+                className="flex w-full gap-[0.4rem]"
                 onClick={() => handleGenderClick('여성')}
               />
               <Button
-                variant={genderValue === '남성' ? 'skyblueBorder' : 'white'}
+                variant={genderValue === '남성' ? 'skyblueBorder' : 'gray2'}
                 label="남성"
                 icon="male"
-                className="flex w-full gap-[0.4rem] bg-background"
+                className="flex w-full gap-[0.4rem]"
                 onClick={() => handleGenderClick('남성')}
               />
             </div>

--- a/src/pages/sign-up/constants/NOTICE.ts
+++ b/src/pages/sign-up/constants/NOTICE.ts
@@ -4,7 +4,7 @@ export const AGE_NOTICE = `메잇볼은 만 19세 이상부터 이용할 수 있
 
 export const AGE_LIMIT_MESSAGE = '만 19세 이상부터 가입이 가능합니다.';
 
-export const NICKNAME_TITLE = `반가워요, 메잇볼에서 \n 사용할 닉네임을 알려주세요.`;
+export const NICKNAME_TITLE = `반가워요! 메잇볼에서 \n 사용할 정보를 알려주세요.`;
 
 export const NICKNAME_RULE_MESSAGE = '공백, 숫자, 특수기호, 한글+영어 혼용 불가';
 

--- a/src/pages/sign-up/constants/validation.ts
+++ b/src/pages/sign-up/constants/validation.ts
@@ -23,7 +23,7 @@ export const NICKNAME_PLACEHOLDER = '2-6자 이내의 닉네임을 입력하세�
 export const BIRTH_PLACEHOLDER = '생년을 YYYY 형태로 입력하세요.';
 
 export const BIRTH_ERROR_MESSAGES = {
-  LENGTH: '4자리 입력만 가능해요.',
+  LENGTH: '숫자로 4자리 입력만 가능해요.',
   NUMBER: '숫자만 입력 가능해요.',
 };
 

--- a/src/shared/assets/svgs/check-filled.svg
+++ b/src/shared/assets/svgs/check-filled.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="38" height="38" viewBox="0 0 38 38" fill="currentColor">
+<svg xmlns="http://www.w3.org/2000/svg"  viewBox="0 0 38 38" fill="currentColor">
 <g clip-path="url(#clip0_1_7659)">
 <mask id="mask0_1_7659" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="38" height="38">
 <rect x="0.3125" y="0.1875" width="37.6562" height="37.6562" fill="#D9D9D9"/>

--- a/src/shared/components/button/button/styles/button-variants.ts
+++ b/src/shared/components/button/button/styles/button-variants.ts
@@ -10,6 +10,7 @@ export const buttonVariants = cva(
         skyblue: 'bg-main-200 text-main-900',
         white: 'bg-white text-gray-700',
         skyblueBorder: 'bg-main-200 text-main-900 outline outline-main-900',
+        gray2: 'bg-background text-gray-700',
       },
       size: {
         M: 'w-full px-[0.8rem] py-[1.2rem]',

--- a/src/shared/components/input/input.tsx
+++ b/src/shared/components/input/input.tsx
@@ -60,7 +60,11 @@ const Input = ({
       </div>
       {messageToShow && (
         <div className="flex-row gap-[0.8rem]">
-          <Icon name="info-filled" size={2} className={iconColorClass} />
+          <Icon
+            name={inputState === 'valid' ? 'check-filled' : 'info-filled'}
+            size={2}
+            className={iconColorClass}
+          />
           <p className={`cap_14_m ${iconColorClass}`}>{messageToShow}</p>
         </div>
       )}


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #252 

## 💎 PR Point

### 변경사항은 다음과 같습니다.
- 회원가입 타이틀 변경 (반가워요 ! 사용할 정보를 알려주세요)
- 생년에 유효성 메세지 4자리로 입력해주세요 -> 숫자 4자리로 입력해주세요
- input 유효성 아이콘 valid할때 check-filled로 되게 수정
- Button 컴포넌트에 gray2 색상을 추가했습니다. 버튼 내부 buttonStyleVariants도 리팩토링 필요할듯하네요 ... 어흑

## 📸 Screenshot
<img width="340" height="883" alt="image" src="https://github.com/user-attachments/assets/f52daa33-dcb3-4acb-8909-d7ca7caf07f9" />
