### PR TITLE
style: footer background 옵션 수정

### DIFF
--- a/src/pages/match/create/create.tsx
+++ b/src/pages/match/create/create.tsx
@@ -24,7 +24,6 @@ const Create = () => {
     return () => clearTimeout(timer);
   }, []);
 
-
   if (isInvalidMatchId(matchId?.toString()) || !matchType) {
     return <Navigate to={ROUTES.ERROR} replace />;
   }

--- a/src/shared/components/bottom-sheet/bottom-sheet-modal.tsx
+++ b/src/shared/components/bottom-sheet/bottom-sheet-modal.tsx
@@ -78,4 +78,3 @@ const BottomSheetModal = ({
 };
 
 export default BottomSheetModal;
-

--- a/src/shared/components/bottom-sheet/game-match/game-match-bottom-sheet.tsx
+++ b/src/shared/components/bottom-sheet/game-match/game-match-bottom-sheet.tsx
@@ -89,4 +89,3 @@ const GameMatchBottomSheet = ({
 };
 
 export default GameMatchBottomSheet;
-

--- a/src/shared/components/footer/footer.tsx
+++ b/src/shared/components/footer/footer.tsx
@@ -1,10 +1,21 @@
 import { COPYRIGHT_NOTICE, MATCHING_PLATFORM_NOTICE } from '@components/footer/constants/legal';
 import Icon from '@components/icon/icon';
 import { EXTERNAL_LINKS } from '@constants/links';
+import { ROUTES } from '@routes/routes-config';
+import clsx from 'clsx';
+import { useLocation } from 'react-router-dom';
 
 const Footer = () => {
+  const { pathname } = useLocation();
+
+  const isHome = pathname === ROUTES.HOME;
+
   return (
-    <footer className="cap_12_m w-full flex-col gap-[4.8rem] bg-gray-200 px-[1.6rem] py-[3.2rem]">
+    <footer
+      className={clsx('cap_12_m w-full flex-col gap-[4.8rem] px-[1.6rem] py-[3.2rem]', {
+        'bg-gray-200': isHome,
+      })}
+    >
       <div className="flex-col gap-[0.8rem]">
         <Icon name="logo-gray" width={9.2} height={2.5} className="text-gray-700" />
         <div className="flex-col gap-[0.4rem] text-gray-700">


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #263 

## 💎 PR Point
홈에 위치한 Footer 컴포넌트랑 그 외 주소에 있는 Footer 두개 색상이달랐어요. 나머지는 bg-background 색상이고, 홈에 있는 Footer만 bg-gray-200 색상이여서 clsx로 옵션 추가했습니다.

```ts
  const { pathname } = useLocation();

  const isHome = pathname === ROUTES.HOME;

  return (
    <footer
      className={clsx('cap_12_m w-full flex-col gap-[4.8rem] px-[1.6rem] py-[3.2rem]', {
        'bg-gray-200': isHome,
      })}
    >
```
