### PR TITLE
feat: (QA/2) 매칭 요청에 유저 닉네임 추가

### DIFF
--- a/src/pages/match/components/mate-header.tsx
+++ b/src/pages/match/components/mate-header.tsx
@@ -5,10 +5,10 @@ interface MateHeaderProps {
   isGroupMatching?: boolean;
 }
 
-const MateHeader = ({ isGroupMatching }: MateHeaderProps) => (
+const MateHeader = ({ isGroupMatching, nickname }: MateHeaderProps) => (
   <section className="gap-[0.8rem] text-center">
     <h1 className="title_24_sb text-gray-black">
-      {isGroupMatching ? MATCHING_HEADER_MESSAGE.group : MATCHING_HEADER_MESSAGE.single}
+      {MATCHING_HEADER_MESSAGE(nickname, !!isGroupMatching)}
     </h1>
     <p className="body_16_m text-gray-600">상대의 정보를 확인하고, 매칭을 요청해 보세요.</p>
   </section>

--- a/src/pages/match/components/mate.tsx
+++ b/src/pages/match/components/mate.tsx
@@ -28,10 +28,7 @@ const Mate = ({ matchId, onRequestClick, isGroupMatching = true }: MateProps) =>
   return (
     <div className="h-full flex-col-between">
       <section className="w-full flex-col-center gap-[4rem] pt-[4rem]">
-        <MateHeader
-          nickname={mates[currentIndex]?.nickname?.[0] ?? ''}
-          isGroupMatching={isGroupMatching}
-        />
+        <MateHeader nickname={data?.nickname ?? ''} isGroupMatching={isGroupMatching} />
         <MateCarousel
           mates={mates}
           currentIndex={currentIndex}

--- a/src/pages/match/constants/matching.ts
+++ b/src/pages/match/constants/matching.ts
@@ -10,8 +10,8 @@ export const MATCHING_COMPLETE_MESSAGE = {
 
 export const MATCHING_HEADER_MESSAGE = (nickname: string, isGroup: boolean) =>
   ({
-    group: `${nickname}님과 딱 맞는 그룹원이에요!`,
-    single: `${nickname}님과 딱 맞는 메이트예요!`,
+    group: `${nickname} 님과 딱 맞는 그룹원이에요!`,
+    single: `${nickname} 님과 딱 맞는 메이트예요!`,
   })[isGroup ? 'group' : 'single'];
 
 export const MATCHING_DESCRIPTION = {
@@ -35,7 +35,7 @@ export const MAX_CREATE_DESCRIPTION = {
 };
 
 export const MATCHING_GUIDE_MESSAGE_TITLE = (nickname: string) =>
-  `${nickname}님을 위한\n맞춤 매칭이 생성되었어요!`;
+  `${nickname} 님을 위한\n맞춤 매칭이 생성되었어요!`;
 
 export const MATCHING_GUIDE_MESSAGE_DESCRIPTION =
   '딱! 맞는 메이트의 요청이 도착하면\n' + "'매칭 현황'에서 확인할 수 있어요.";

--- a/src/pages/match/constants/matching.ts
+++ b/src/pages/match/constants/matching.ts
@@ -8,18 +8,19 @@ export const MATCHING_COMPLETE_MESSAGE = {
   single: '상대방이 요청을 승인하면 매칭이 성사돼요.',
 };
 
-export const MATCHING_HEADER_MESSAGE = {
-  group: '사용자님과 딱 맞는 그룹원이에요!',
-  single: '사용자님과 딱 맞는 메이트예요!',
-};
+export const MATCHING_HEADER_MESSAGE = (nickname: string, isGroup: boolean) =>
+  ({
+    group: `${nickname}님과 딱 맞는 그룹원이에요!`,
+    single: `${nickname}님과 딱 맞는 메이트예요!`,
+  })[isGroup ? 'group' : 'single'];
 
 export const MATCHING_DESCRIPTION = {
   group: {
-    description: '그룹 매칭은 최대 2건까지 신청할 수 있어요.',
+    description: '동시에 진행할 수 있는 그룹 매칭은 최대 2개예요.',
     subDescription: '단, 하루에 한 경기만 매칭이 성사되며 같은 날짜의 중복 매칭은 불가능해요!',
   },
   single: {
-    description: '1:1 매칭은 최대 3건까지 요청할 수 있어요.',
+    description: '동시에 진행할 수 있는 1:1 매칭은 최대 3개예요.',
     subDescription: '단, 하루에 한 경기만 매칭이 성사되며 같은 날짜의 중복 매칭은 불가능해요!',
   },
 };

--- a/src/pages/result/components/matching-receive-view.tsx
+++ b/src/pages/result/components/matching-receive-view.tsx
@@ -45,8 +45,7 @@ const MatchingReceiveView = ({ isGroupMatching = true }: MatchingReceiveViewProp
       onSuccess: () => {
         navigate(`${ROUTES.RESULT(matchId)}?type=fail`);
       },
-      onError: (error) => {
-        console.error('매칭 거절 실패:', error);
+      onError: () => {
         navigate(ROUTES.ERROR);
       },
     });
@@ -58,8 +57,7 @@ const MatchingReceiveView = ({ isGroupMatching = true }: MatchingReceiveViewProp
         const resultType = cardType === 'group' ? 'agree' : 'success';
         navigate(`${ROUTES.RESULT(matchId)}?type=${resultType}`);
       },
-      onError: (error) => {
-        console.error('매칭 수락 실패:', error);
+      onError: () => {
         navigate(ROUTES.ERROR);
       },
     });

--- a/src/shared/types/match-types.ts
+++ b/src/shared/types/match-types.ts
@@ -208,7 +208,7 @@ export interface getGroupMatchMate {
 /**
  * 매칭 요청 상세조회용 Mate
  * get
- * /v1/users/match-detail/{matchId}
+ * /v1/users/match/{matchId}
  */
 export interface matchDetailMateSimple extends baseMate {
   age: string;
@@ -223,8 +223,9 @@ export interface matchDetailMateSimple extends baseMate {
 /**
  * 매칭 요청 상세조회 응답
  * get
- * /v1/users/match-detail/{matchId}
+ * /v1/users/match/{matchId}
  */
 export interface getMatchDetailResponse {
+  nickname: string;
   mates: matchDetailMateSimple[];
 }


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #257

## ☀️ New-insight

- 매칭 상세 API 응답 구조에서 `nickname`은 배열 외부에 위치하며, 이는 현재 로그인한 사용자의 닉네임입니다.
- `mates` 배열 내부의 `nickname`은 매칭 상대방의 닉네임입니다.
- 헤더에는 현재 사용자의 닉네임(`data.nickname`)을 표시해야 하며, 카드에는 상대방들의 정보(`mates[].nickname`)를 표시해야 합니다.

## 💎 PR Point

### 트러블 슈팅
- **문제**: 매칭 상세 페이지 헤더에 상대방 닉네임의 첫 글자만 표시되는 현상
- **원인**: `mate.tsx`에서 MateHeader에 `mates[currentIndex]?.nickname?.[0]` (상대방 닉네임의 첫 글자)를 전달하고 있었음
- **해결**: API 응답의 `data.nickname` (현재 사용자 닉네임)을 MateHeader에 전달하도록 수정

### 수정된 파일
1. **`src/pages/match/components/mate.tsx`**
   - MateHeader의 nickname prop을 `mates[currentIndex]?.nickname?.[0]`에서 `data?.nickname`으로 변경
   - 이제 헤더에 현재 사용자의 전체 닉네임이 정확히 표시되었습니다.

2. **`src/pages/home/components/match-list-section.tsx`**
   - 홈에서 매칭 상세로 이동할 때 `newRequest=false` 파라미터를 추가했습니다.
   - 이를 통해 기존 매칭 요청에 대한 상세 정보를 올바르게 조회할 수 있었습니다.

### API 응답 구조 이해...
```json
{
  "nickname": "메잇볼",        // 현재 사용자 닉네임 (헤더에 표시)
  "mates": [
    {
      "nickname": "다진마늘땨땨",  // 상대방 닉네임 (카드에 표시)
      // ... 기타 상대방 정보
    }
  ]
}
```

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 매칭 헤더 메시지가 닉네임을 포함한 개인화된 문구로 표시됩니다.

* **버그 수정**
  * 매칭 헤더에 표시되는 닉네임이 올바르게 상위 데이터에서 전달됩니다.

* **문서**
  * API 경로 및 응답 타입 주석이 최신 정보로 수정되었습니다.

* **스타일**
  * 매칭 설명 문구가 더 간결하고 명확하게 개선되었습니다.

* **리팩터**
  * 에러 발생 시 콘솔 로그 없이 오류 페이지로 바로 이동하도록 처리 방식이 단순화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->