### PR TITLE
fix: (QA/2) 유저 카드에서 응원하는 팀이 없는 경우 레이아웃 깨지는 문제 해결

### DIFF
--- a/src/shared/components/chip/chip-list.tsx
+++ b/src/shared/components/chip/chip-list.tsx
@@ -10,12 +10,10 @@ interface ChipListProps {
 }
 
 const ChipList = ({ names }: ChipListProps) => {
-  const validNames = names.filter((name) =>
-    Object.keys(chipVariantOptions.bgColor).includes(name)
-  );
+  const validNames = names.filter((name) => Object.keys(chipVariantOptions.bgColor).includes(name));
 
   return (
-    <ul className="flex gap-[0.8rem]">
+    <ul className="flex min-h-[2.6rem] gap-[0.8rem]">
       {validNames.map((name) => (
         <li key={name}>
           <Chip label={name} bgColor={name} textColor={name} />

--- a/src/shared/components/chip/chip-list.tsx
+++ b/src/shared/components/chip/chip-list.tsx
@@ -1,5 +1,6 @@
 import Chip from '@components/chip/chip';
 import type { chipVariants } from '@components/chip/styles/chip-variants';
+import { chipVariantOptions } from '@components/chip/styles/chip-variants';
 import type { VariantProps } from 'class-variance-authority';
 
 export type ChipColor = NonNullable<VariantProps<typeof chipVariants>['bgColor']>;
@@ -9,9 +10,13 @@ interface ChipListProps {
 }
 
 const ChipList = ({ names }: ChipListProps) => {
+  const validNames = names.filter((name) =>
+    Object.keys(chipVariantOptions.bgColor).includes(name)
+  );
+
   return (
     <ul className="flex gap-[0.8rem]">
-      {names.map((name) => (
+      {validNames.map((name) => (
         <li key={name}>
           <Chip label={name} bgColor={name} textColor={name} />
         </li>


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #272

## ☀️ New-insight

- 기존 `ChipList`는 `chipVariantOptions`에 정의되지 않은 값도 그대로 렌더링하고 있었습니다.
- `chipVariantOptions.bgColor`에 없는 값은 chip을 생성하지 않도록 필터링 로직을 추가했습니다.
```tsx
const validNames = names.filter((name) => Object.keys(chipVariantOptions.bgColor).includes(name));
```

## 💎 PR Point

- `ChipList`에서 `validNames`를 생성하여 `chipVariantOptions.bgColor`의 키에 포함된 값만 렌더링하도록 개선했습니다.
- `Chip`의 `label`, `bgColor`, `textColor`가 유효한 값만 반영되도록 수정하였습니다.

## 📸 Screenshot
<img width="300" alt="image" src="https://github.com/user-attachments/assets/ff6ec533-2aaa-40dc-80f9-7044b4152c4b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 유효한 칩 색상만 화면에 표시되도록 칩 목록 필터링이 개선되었습니다.

* **스타일**
  * 칩 목록의 최소 높이가 추가되어 레이아웃이 더 안정적으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->