### PR TITLE
style: (QA/2) 텍스트와 캘린더 사이 간격 조정

### DIFF
--- a/src/pages/onboarding/components/date-select.tsx
+++ b/src/pages/onboarding/components/date-select.tsx
@@ -32,7 +32,7 @@ const DateSelect = () => {
   });
 
   return (
-    <div className="h-full w-full flex-col-between px-[1.6rem] pt-[1.6rem]">
+    <div className="h-full w-full flex-col-between gap-[5.6rem] px-[1.6rem] pt-[3.2rem]">
       <div className="flex-col-center gap-[0.8rem]">
         <p className="head_20_sb text-gray-black">어떤 경기를 직관하고 싶으신가요?</p>
         <p className="cap_14_m text-gray-600">
@@ -40,7 +40,7 @@ const DateSelect = () => {
         </p>
       </div>
 
-      <div className="w-full flex-col-center flex-grow">
+      <div className="w-full flex-grow">
         <MonthCalendar
           value={currentMonth}
           selectedDate={selectedDate}

--- a/src/shared/styles/custom-utilities.css
+++ b/src/shared/styles/custom-utilities.css
@@ -58,7 +58,7 @@
   }
 
   .onboarding-layout {
-    @apply mt-[3.2rem] h-full w-full flex flex-col justify-between items-center;
+    @apply mt-[5rem] h-full w-full flex flex-col justify-between items-center;
   }
 
   .onboarding-inner {


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #278 

## ☀️ New-insight

<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->

## 💎 PR Point

- 캘린더 페이지 progress bar와 텍스트 사이 padding 값 조절했어요.
- 온보딩 전체 페이지에서 progress bar와 아이콘 사이 간격이 좁은 것 같아서 협의 후에 전체 레이아웃 margin 수정했어요.
- 처음엔 온보딩 캘린더 중앙 고정으로 협의 보고 진행했는데, 위치 고정이면 좋겠다고 하셔서 ^^ 수정햇어요 ㅎ

## 📸 Screenshot
<img width="1377" height="1103" alt="스크린샷 2025-07-18 오후 7 30 30" src="https://github.com/user-attachments/assets/d3633beb-c7a8-4be0-9091-c217bb535a84" />
<img width="1377" height="1103" alt="스크린샷 2025-07-18 오후 7 30 40" src="https://github.com/user-attachments/assets/9899ca03-6ba3-492e-9f5c-10831b0c0184" />
<img width="1377" height="1103" alt="스크린샷 2025-07-18 오후 7 30 50" src="https://github.com/user-attachments/assets/a178eaa3-4352-4d09-a414-3e3a95925f89" />
