### PR TITLE
fix: (QA/2) 그룹 매칭 수락 시 매칭 현황으로 네비게이트

### DIFF
--- a/src/pages/result/components/matching-receive-view.tsx
+++ b/src/pages/result/components/matching-receive-view.tsx
@@ -55,8 +55,11 @@ const MatchingReceiveView = ({ isGroupMatching = true }: MatchingReceiveViewProp
   const handleAccept = () => {
     acceptMatch(parsedId, {
       onSuccess: () => {
-        const resultType = cardType === 'group' ? 'agree' : 'success';
-        navigate(`${ROUTES.RESULT(matchId)}?type=${resultType}`);
+        if (cardType === 'group') {
+          navigate(ROUTES.MATCH);
+        } else {
+          navigate(`${ROUTES.RESULT(matchId)}?type=success`);
+        }
       },
       onError: (error) => {
         console.error('매칭 수락 실패:', error);


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #279 

## 💎 PR Point

- 그룹 매칭 수락 시 매칭 현황 페이지로 네비게이트 되도록 수정했습니다.(이전에는 /result/{matchId}?type=agree 페이지로 이동했었음)
- 일대일 매칭 수락 시에는 이전과 동일하게 /result/{matchId}?type=success 페이지로 이동합니다.

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 매칭 수락 후 그룹 카드의 경우 올바른 화면으로 이동하도록 네비게이션 동작이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->