### PR TITLE
fix: 주간 캘린더에서의 toast 오류 해결

### DIFF
--- a/src/pages/home/components/calendar-section.tsx
+++ b/src/pages/home/components/calendar-section.tsx
@@ -25,8 +25,9 @@ const CalendarSection = ({
   };
 
   return (
-    <section className="sticky top-0 z-[var(--z-under-header-section)] mt-[-0.1rem] bg-gray-black px-[1.6rem] pt-[2.4rem]">
+    <section className="sticky top-0 z-[var(--z-under-header-section)] bg-gray-black px-[1.6rem] pt-[2.4rem]">
       <WeekCalendar
+        entryDate={new Date()}
         baseDate={baseWeekDate}
         value={selectedDate}
         onChange={(date) => {

--- a/src/pages/home/components/home-calendar-tap.tsx
+++ b/src/pages/home/components/home-calendar-tap.tsx
@@ -13,6 +13,7 @@ const HomeCalendarTap = () => {
   return (
     <div className="sticky top-[5.6rem] z-10 bg-black px-[1.6rem] pt-[2.4rem]">
       <WeekCalendar
+        entryDate={new Date()}
         baseDate={baseWeekDate}
         value={selectedDate}
         onChange={(date) => {

--- a/src/shared/components/calendar/calendar.stories.tsx
+++ b/src/shared/components/calendar/calendar.stories.tsx
@@ -57,6 +57,7 @@ export const Week: Story = {
 
     return (
       <WeekCalendar
+        entryDate={new Date()}
         value={selectedDate}
         baseDate={baseWeekDate}
         onChange={(date) => setSelectedDate(date)}

--- a/src/shared/components/calendar/week-calendar.tsx
+++ b/src/shared/components/calendar/week-calendar.tsx
@@ -8,12 +8,13 @@ import { calendarDayVariants } from '@/shared/components/calendar/styles/calenda
 import { showErrorToast } from '@/shared/utils/show-error-toast';
 
 interface WeekCalendarProps {
+  entryDate: Date;
   baseDate: Date;
   value: Date;
   onChange: (date: Date) => void;
 }
 
-const WeekCalendar = ({ baseDate, value, onChange }: WeekCalendarProps) => {
+const WeekCalendar = ({ entryDate, baseDate, value, onChange }: WeekCalendarProps) => {
   const days = getWeekDays(baseDate);
 
   return (
@@ -30,7 +31,7 @@ const WeekCalendar = ({ baseDate, value, onChange }: WeekCalendarProps) => {
             : 'text-gray-500';
 
         const handleClick = (day: Date) => {
-          const isBlocked = day <= addDays(baseDate, 1);
+          const isBlocked = day <= addDays(entryDate, 1);
 
           if (isBlocked) {
             showErrorToast(DATE_SELECT_TOAST_MESSAGE, {


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #293 

## ☀️ New-insight

월간 캘린더에는 entryDate를 따로 설정해서 진입 날짜 기준 이틀에 toast를 띄웠는데, 주간 캘린더에는 기존에 있던 baseDate를 기준으로 이틀 진입 시 toast를 띄우게 설계했어요.
그.랬.더.니. 월간 캘린더에서 다른 날짜를 선택하고 주간 캘린더로 돌아갔을 때, 맨 앞 이틀이 toast가 뜨는 error가 있었습니다ㅜㅜ

## 💎 PR Point

월간 캘린더에서처럼 entryDate를 따로 설정해서 진입 날짜 기준 이틀만 toast 뜨게 해서 해~결~했습니닿ㅎ

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 캘린더에서 선택 불가능한 날짜의 기준이 변경되어, 더 정확한 날짜 선택 제한이 적용됩니다.

* **스타일**
  * 캘린더 섹션의 상단 여백이 조정되어 화면 배치가 개선되었습니다.

* **테스트/스토리**
  * 캘린더 컴포넌트의 스토리에 날짜 속성이 추가되어, 실제 동작과 일치하도록 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->