### PR TITLE
fix: (QA/2) 그룹 상세 조회 그룹원 리스트 역순 정렬

### DIFF
--- a/src/pages/match/components/mate-carousel.tsx
+++ b/src/pages/match/components/mate-carousel.tsx
@@ -23,6 +23,8 @@ const MateCarousel = ({ mates, currentIndex, onDotClick, isGroupMatching }: Mate
     onChange: onDotClick,
   });
 
+  const reversedMates = [...mates].reverse();
+
   return (
     <section className="w-full flex-col gap-[1.6rem] overflow-hidden" aria-label="매칭 캐러셀">
       <ul
@@ -34,7 +36,7 @@ const MateCarousel = ({ mates, currentIndex, onDotClick, isGroupMatching }: Mate
         aria-roledescription="carousel"
         aria-live="polite"
       >
-        {mates.map((mate, index) => (
+        {reversedMates.map((mate, index) => (
           <li
             key={mate.id}
             aria-roledescription="slide"


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #295 

## 💎 PR Point

- 홈 매칭 리스트에 생성된 그룹 카드 선택 시, 그룹장이 제일 먼저 보이지 않는 문제가 있었습니다. 백에서 받는 데이터는 최근 그룹원이 된 순서대로 data를 주고 있어서(그룹장이 가장 먼저 그룹을 생성했으므로 배열의 맨 마지막 순서에 있었음) 스프레드 연산자로 reverse해서 배열을 역순서로 바꾸어 해결했습니다.

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 캐러셀에서 매칭 아이템의 표시 순서가 반대로 변경되었습니다. 이제 슬라이드가 역순으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->