### PR TITLE
style: (QA/2)카드 프로필 테두리 border로 변경

### DIFF
--- a/src/shared/components/card/match-card/components/card-profile-image.tsx
+++ b/src/shared/components/card/match-card/components/card-profile-image.tsx
@@ -21,8 +21,15 @@ const CardProfile = ({ type, imgUrl = [] }: CardProfileProps) => {
     filledImages.forEach((url, order) => {
       const key = url || `profile-slot-${order}`;
       profileElements.push(
-        <div key={key} className={cn(zIndexClasses[order])}>
-          <Icon size={2.8} name="profile" className={cn(profileVariants({ type }))} />
+        <div
+          key={key}
+          className={cn(
+            'flex items-center justify-center overflow-hidden rounded-full',
+            zIndexClasses[order],
+            profileVariants({ type }),
+          )}
+        >
+          <Icon size={2.8} name="profile" className={cn('rounded-full text-gray-black')} />
         </div>,
       );
     });
@@ -33,11 +40,13 @@ const CardProfile = ({ type, imgUrl = [] }: CardProfileProps) => {
         <div
           key={`empty-slot-${slotIndex}`}
           className={cn(
+            'flex-row-center overflow-hidden rounded-full',
             profileVariants({ type }),
-            'flex-row-center bg-gray-400',
             zIndexClasses[slotIndex],
           )}
-        />,
+        >
+          <div className="h-[2.8rem] w-[2.8rem] rounded-full bg-gray-400" />
+        </div>,
       );
     });
 
@@ -45,8 +54,13 @@ const CardProfile = ({ type, imgUrl = [] }: CardProfileProps) => {
   }
 
   return (
-    <div className="flex items-center">
-      <Icon width={6} height={6} name="profile" className={cn(profileVariants({ type }))} />
+    <div className="flex items-center overflow-hidden rounded-full">
+      <Icon
+        width={6}
+        height={6}
+        name="profile"
+        className={cn('overflow-hidden rounded-full', profileVariants({ type }))}
+      />
     </div>
   );
 };

--- a/src/shared/components/card/match-card/styles/card-variants.ts
+++ b/src/shared/components/card/match-card/styles/card-variants.ts
@@ -19,13 +19,13 @@ export const cardVariants = cva('relative w-full rounded-[12px] bg-white', {
   },
 });
 
-export const profileVariants = cva('aspect-square rounded-full object-cover', {
+export const profileVariants = cva('overflow-hidden rounded-full object-cover', {
   variants: {
     type: {
-      single: 'h-[6rem] w-[6rem] outline outline-[1px] outline-gray-900',
-      group: 'h-[2.8rem] w-[2.8rem] outline outline-[1px] outline-main-600',
-      detailed: 'h-[8.2rem] w-[8.2rem] outline outline-[1px] outline-gray-900',
-      user: 'h-[8.2rem] w-[8.2rem] outline outline-[1px] outline-gray-900',
+      single: 'h-[6rem] w-[6rem] border border-gray-900',
+      group: 'h-[2.8rem] w-[2.8rem] border border-main-600',
+      detailed: 'h-[8.2rem] w-[8.2rem] border border-gray-900',
+      user: 'h-[8.2rem] w-[8.2rem] border border-gray-900',
     },
   },
   defaultVariants: {


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #297

## ☀️ New-insight

outline은 항상 사각형 박스로 표시되기 때문에 rounded-full을 줘도 완전한 원형 outline은 만들 수 없다고 합니다... 근데 왜 기기마다 차이가 있었는지 모르겠습니다,, 대신 border를 사용해서 문제를 해결할 수 있었습니다!! border는 rounded-full과 함께 사용하면 완벽한 원형 테두리가 된다고 하네요..

## 💎 PR Point

profileVariants에 outline 대신 border를 사용하도록 수정했습니다.

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 프로필 이미지와 컨테이너의 모서리가 더 둥글게 처리되고, 오버플로우가 잘려 보이도록 스타일이 개선되었습니다.
  * 그룹 및 단일 프로필 이미지 모두에 일관된 둥근 테두리와 클리핑 효과가 적용되었습니다.
  * 프로필 이미지 테두리 스타일이 outline에서 border로 변경되어 더욱 깔끔하게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->