### PR TITLE
refactor: offset 기반으로 toast 위치 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "date-fns": "^4.1.0",
     "framer-motion": "^12.23.3",
     "react": "^19.1.0",
-    "react-compact-toast": "^0.1.6",
+    "react-compact-toast": "^0.2.0",
     "react-dom": "^19.1.0",
     "react-error-boundary": "^6.0.0",
     "react-hook-form": "^7.59.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: ^19.1.0
         version: 19.1.0
       react-compact-toast:
-        specifier: ^0.1.6
-        version: 0.1.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^0.2.0
+        version: 0.2.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
@@ -3385,8 +3385,8 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  react-compact-toast@0.1.6:
-    resolution: {integrity: sha512-dYV1IzyVFK29kw18rRYP2jpCZh/Uspb3vNwrTKGqxIXY8OLgopeYm2tlk4bEXlOA7u8pCB+1Arp/muoaHwt5hA==}
+  react-compact-toast@0.2.0:
+    resolution: {integrity: sha512-VtYSjSsr8x0Rhx0rTYjKa49/EX7B/3c7Idu9/XbxkQ5DPeX1PcFFPIWn0AZPqA2CscZTX7FDJR0fxt56RC3y1w==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^18 || ^19
@@ -7146,7 +7146,7 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  react-compact-toast@0.1.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  react-compact-toast@0.2.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)

--- a/src/pages/home/components/calendar-bottom-sheet.tsx
+++ b/src/pages/home/components/calendar-bottom-sheet.tsx
@@ -38,7 +38,7 @@ const CalendarBottomSheet = ({
           selectedDate={localSelectedDate}
           onWeekChange={setLocalSelectedDate}
           onMonthChange={setLocalSelectedDate}
-          toastBottomOffset="5.3rem"
+          toastBottomOffset="8.3rem"
         />
       </div>
       <div className="p-[1.6rem]">

--- a/src/pages/onboarding/components/date-select.tsx
+++ b/src/pages/onboarding/components/date-select.tsx
@@ -47,7 +47,7 @@ const DateSelect = () => {
           selectedDate={selectedDate}
           onWeekChange={handleDateSelect}
           onMonthChange={handleMonthChange}
-          toastBottomOffset="-1.4rem"
+          toastBottomOffset="2.4rem"
         />
       </div>
 

--- a/src/shared/components/bottom-sheet/bottom-sheet-modal.tsx
+++ b/src/shared/components/bottom-sheet/bottom-sheet-modal.tsx
@@ -41,13 +41,9 @@ const BottomSheetModal = ({
         const status = (error as AxiosError)?.response?.status;
 
         if (status === MATCH_REQUEST_ERROR_MESSAGES.TOO_MANY_REQUESTS.status) {
-          showErrorToast(MATCH_REQUEST_ERROR_MESSAGES.TOO_MANY_REQUESTS.message, {
-            bottom: '5.3rem',
-          });
+          showErrorToast(MATCH_REQUEST_ERROR_MESSAGES.TOO_MANY_REQUESTS.message, '8.3rem');
         } else if (status === MATCH_REQUEST_ERROR_MESSAGES.DUPLICATE_MATCH.status) {
-          showErrorToast(MATCH_REQUEST_ERROR_MESSAGES.DUPLICATE_MATCH.message, {
-            bottom: '5.3rem',
-          });
+          showErrorToast(MATCH_REQUEST_ERROR_MESSAGES.DUPLICATE_MATCH.message, '8.3rem');
         }
       },
     });

--- a/src/shared/components/bottom-sheet/game-match/game-match-bottom-sheet.tsx
+++ b/src/shared/components/bottom-sheet/game-match/game-match-bottom-sheet.tsx
@@ -89,13 +89,9 @@ const GameMatchBottomSheet = ({
           const status = (error as AxiosError)?.response?.status;
 
           if (status === MATCH_REQUEST_ERROR_MESSAGES.TOO_MANY_REQUESTS.status) {
-            showErrorToast(MATCH_REQUEST_ERROR_MESSAGES.TOO_MANY_REQUESTS.message, {
-              bottom: '5.3rem',
-            });
+            showErrorToast(MATCH_REQUEST_ERROR_MESSAGES.TOO_MANY_REQUESTS.message, '8.3rem');
           } else if (status === MATCH_REQUEST_ERROR_MESSAGES.DUPLICATE_MATCH.status) {
-            showErrorToast(MATCH_REQUEST_ERROR_MESSAGES.DUPLICATE_MATCH.message, {
-              bottom: '5.3rem',
-            });
+            showErrorToast(MATCH_REQUEST_ERROR_MESSAGES.DUPLICATE_MATCH.message, '8.3rem');
           }
         },
       },

--- a/src/shared/components/calendar/month-calendar.tsx
+++ b/src/shared/components/calendar/month-calendar.tsx
@@ -22,7 +22,7 @@ interface MonthCalendarProps {
   selectedDate?: Date | null;
   onWeekChange: (date: Date) => void;
   onMonthChange: (date: Date) => void;
-  toastBottomOffset?: '4.6rem' | '5.3rem' | '-1.4rem';
+  toastBottomOffset?: '7.6rem' | '8.3rem' | '2.4rem';
 }
 
 const MonthCalendar = ({
@@ -77,9 +77,7 @@ const MonthCalendar = ({
             const handleClick = (day: Date) => {
               const isBlocked = day <= addDays(entryDate, 1);
               if (isBlocked) {
-                showErrorToast(DATE_SELECT_TOAST_MESSAGE, {
-                  bottom: toastBottomOffset ?? '-1.4rem',
-                });
+                showErrorToast(DATE_SELECT_TOAST_MESSAGE, toastBottomOffset ?? '2.4rem');
                 return;
               }
               onWeekChange(day);

--- a/src/shared/components/calendar/week-calendar.tsx
+++ b/src/shared/components/calendar/week-calendar.tsx
@@ -34,9 +34,7 @@ const WeekCalendar = ({ entryDate, baseDate, value, onChange }: WeekCalendarProp
           const isBlocked = day <= addDays(entryDate, 1);
 
           if (isBlocked) {
-            showErrorToast(DATE_SELECT_TOAST_MESSAGE, {
-              bottom: '4.6rem',
-            });
+            showErrorToast(DATE_SELECT_TOAST_MESSAGE, '7.6rem');
             return;
           }
           onChange(day);

--- a/src/shared/utils/show-error-toast.tsx
+++ b/src/shared/utils/show-error-toast.tsx
@@ -4,12 +4,8 @@ import { toast } from 'react-compact-toast';
 export const showErrorToast = (message: string, offset: string = '8.3rem') => {
   toast({
     text: message,
-    icon: (
-      <div className="mr-[0.4rem]">
-        <Icon name="error" />
-      </div>
-    ),
-    autoClose: 3000,
+    icon: <Icon name="error" className="mr-[0.4rem]" />,
+    autoClose: 300000,
     position: 'bottomCenter',
     offset,
     className:

--- a/src/shared/utils/show-error-toast.tsx
+++ b/src/shared/utils/show-error-toast.tsx
@@ -1,23 +1,14 @@
 import Icon from '@components/icon/icon';
 import { toast } from 'react-compact-toast';
 
-export const showErrorToast = (
-  message: string,
-  options?: { bottom?: '-1.4rem' | '4.6rem' | '5.3rem' },
-) => {
-  const bottomClassMap = {
-    '-1.4rem': 'bottom-[-1.4rem]',
-    '4.6rem': 'bottom-[4.6rem]',
-    '5.3rem': 'bottom-[5.3rem]',
-  };
-
-  const bottomClass = bottomClassMap[options?.bottom ?? '5.3rem'];
-
+export const showErrorToast = (message: string, offset: string = '8.3rem') => {
   toast({
     text: message,
     icon: <Icon name="error" />,
     autoClose: 3000,
     position: 'bottomCenter',
-    className: `min-h-[4.5rem]! max-w-[calc(43rem-3.2rem)] w-[calc(100%-3.2rem)] cap_14_m text-gray-white rounded-[12px] gap-[0.8rem] bg-gray-900 ${bottomClass}`,
+    offset,
+    className:
+      'min-h-[4.5rem]! max-w-[calc(43rem-3.2rem)] w-[calc(100%-3.2rem)] cap_14_m text-gray-white rounded-[12px] gap-[0.8rem] bg-gray-900',
   });
 };

--- a/src/shared/utils/show-error-toast.tsx
+++ b/src/shared/utils/show-error-toast.tsx
@@ -4,11 +4,15 @@ import { toast } from 'react-compact-toast';
 export const showErrorToast = (message: string, offset: string = '8.3rem') => {
   toast({
     text: message,
-    icon: <Icon name="error" />,
-    autoClose: 3000,
+    icon: (
+      <div className="mr-[0.4rem]">
+        <Icon name="error" />
+      </div>
+    ),
+    autoClose: 300000,
     position: 'bottomCenter',
     offset,
     className:
-      'min-h-[4.5rem]! max-w-[calc(43rem-3.2rem)] w-[calc(100%-3.2rem)] cap_14_m text-gray-white rounded-[12px] gap-[0.8rem] bg-gray-900',
+      'min-h-[4.5rem]! max-w-[calc(43rem-3.2rem)] w-[calc(100%-3.2rem)] cap_14_m text-gray-white rounded-[12px] bg-gray-900',
   });
 };

--- a/src/shared/utils/show-error-toast.tsx
+++ b/src/shared/utils/show-error-toast.tsx
@@ -9,7 +9,7 @@ export const showErrorToast = (message: string, offset: string = '8.3rem') => {
         <Icon name="error" />
       </div>
     ),
-    autoClose: 300000,
+    autoClose: 3000,
     position: 'bottomCenter',
     offset,
     className:

--- a/src/shared/utils/show-error-toast.tsx
+++ b/src/shared/utils/show-error-toast.tsx
@@ -5,7 +5,7 @@ export const showErrorToast = (message: string, offset: string = '8.3rem') => {
   toast({
     text: message,
     icon: <Icon name="error" className="mr-[0.4rem]" />,
-    autoClose: 300000,
+    autoClose: 3000,
     position: 'bottomCenter',
     offset,
     className:


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #301 

## ☀️ New-insight

- 기존에는 라이브러리 내 기본 bottom 값이 고정되어 있어 bottom 값을 따로 계산해서 적용했던 이슈가 있었습니다.
- 라이브러리 버전이 업데이트되면서 offset 값을 직접 지정할 수 있게 되었고, 이번에 해당 기능을 반영했습니다!

## 💎 PR Point

- 피그마에 명시된 디자인 기준에 맞춰 offset 값을 설정했습니다.
- 추가로 디쟌쌤들이 qa 때 발견하지 못했던 것이 있었는데요..ㅎ (사실 전 흐린눈..했는데 못찾으시길래 넘겼어요^^) 아이콘과 텍스트 사이의 간격이 `0.8rem`이어야 하는데, 기존에는 className으로 gap 값을 설정했음에도 적용되지 않고 있었습니다.ㅜㅜ 라이브러리 구조상 className으로는 두 요소 간의 간격을 조절할 수 없었고, 대신 아이콘 쪽에 `margin-right`를 직접 주는 방식으로 해결했습니다~!

## 📸 Screenshot
<img width="405" height="696" alt="스크린샷 2025-07-31 오후 5 15 19" src="https://github.com/user-attachments/assets/2d2db720-f4a2-4817-902b-430474f23536" />
<img width="412" height="283" alt="스크린샷 2025-07-31 오후 5 15 38" src="https://github.com/user-attachments/assets/a4b162f3-bdb7-4734-862d-b2de6fcddcb9" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **버그 수정**
  * 오류 토스트 메시지의 위치가 조정되어 더 일관된 위치에서 표시됩니다.

* **리팩터**
  * 오류 토스트 표시 방식이 간소화되어 위치 지정이 더 직관적으로 변경되었습니다.
  * 달력 컴포넌트에서 토스트 위치 기본값이 업데이트되었습니다.

* **종속성 업데이트**
  * "react-compact-toast" 라이브러리가 최신 버전으로 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->