### PR TITLE
feat: SP1 마이페이지 수정 및 로그아웃 api 연결

### DIFF
--- a/src/pages/profile/constants/link.ts
+++ b/src/pages/profile/constants/link.ts
@@ -1,0 +1,3 @@
+export const REQUEST_LINK = 'https://open.kakao.com/o/su2KJENh';
+
+export const FEEDBACK_LINK = 'https://smore.im/form/jlMGj3m0v3';

--- a/src/pages/profile/profile.tsx
+++ b/src/pages/profile/profile.tsx
@@ -14,6 +14,7 @@ const Profile = () => {
     <div className="h-full flex-col-between">
       <div className="w-full flex-col-center gap-[1.6rem] px-[1.6rem] pt-[1.6rem] pb-[5.6rem]">
         <Card
+          className="!shadow-none"
           type="user"
           nickname={data.nickname ?? ''}
           imgUrl={[data.imgUrl ?? '']}
@@ -24,7 +25,7 @@ const Profile = () => {
           introduction={data.introduction ?? ''}
           chips={[(data.team ?? '') as ChipColor, (data.style ?? '') as ChipColor]}
         />
-        <Button size="L" label="매칭 조건 재설정 하기" />
+        <Button size="L" label="프로필 · 매칭 조건 수정" />
       </div>
       <Footer />
     </div>

--- a/src/pages/profile/profile.tsx
+++ b/src/pages/profile/profile.tsx
@@ -57,7 +57,7 @@ const Profile = () => {
           type="button"
           onClick={() => logout()}
           aria-label="로그아웃"
-          className="cap_14_m py-[0.8rem] text-gray-800"
+          className="cap_14_m cursor-pointer py-[0.8rem] text-gray-800"
         >
           <p>로그아웃</p>
         </button>

--- a/src/pages/profile/profile.tsx
+++ b/src/pages/profile/profile.tsx
@@ -2,6 +2,7 @@ import { userQueries } from '@apis/user/user-queries';
 import Button from '@components/button/button/button';
 import Card from '@components/card/match-card/card';
 import type { ChipColor } from '@components/chip/chip-list';
+import Divider from '@components/divider/divider';
 import Footer from '@components/footer/footer';
 import { useQuery } from '@tanstack/react-query';
 
@@ -27,6 +28,7 @@ const Profile = () => {
         />
         <Button size="L" label="프로필 · 매칭 조건 수정" />
       </div>
+      <Divider thickness={0.4} color="bg-gray-200" />
       <Footer />
     </div>
   );

--- a/src/pages/profile/profile.tsx
+++ b/src/pages/profile/profile.tsx
@@ -6,6 +6,7 @@ import type { ChipColor } from '@components/chip/chip-list';
 import Divider from '@components/divider/divider';
 import Footer from '@components/footer/footer';
 import { useMutation, useQuery } from '@tanstack/react-query';
+import { FEEDBACK_LINK, REQUEST_LINK } from './constants/link';
 
 const Profile = () => {
   const { data } = useQuery(userQueries.USER_INFO());
@@ -41,7 +42,7 @@ const Profile = () => {
           type="button"
           aria-label="문의하기"
           className="cap_14_m py-[0.8rem] text-gray-800"
-          onClick={() => handleClick('https://notion')}
+          onClick={() => handleClick(REQUEST_LINK)}
         >
           <p>문의하기</p>
         </button>
@@ -49,7 +50,7 @@ const Profile = () => {
           type="button"
           aria-label="의견 보내기"
           className="cap_14_m py-[0.8rem] text-gray-800"
-          onClick={() => handleClick('https://notion')}
+          onClick={() => handleClick(FEEDBACK_LINK)}
         >
           <p>의견 보내기</p>
         </button>

--- a/src/pages/profile/profile.tsx
+++ b/src/pages/profile/profile.tsx
@@ -1,13 +1,16 @@
+import { userMutations } from '@apis/user/user-mutations';
 import { userQueries } from '@apis/user/user-queries';
 import Button from '@components/button/button/button';
 import Card from '@components/card/match-card/card';
 import type { ChipColor } from '@components/chip/chip-list';
 import Divider from '@components/divider/divider';
 import Footer from '@components/footer/footer';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 
 const Profile = () => {
   const { data } = useQuery(userQueries.USER_INFO());
+
+  const { mutate: logout } = useMutation(userMutations.LOGOUT());
 
   const handleClick = (link: string) => {
     window.open(link, '_blank', 'noopener,noreferrer');
@@ -51,7 +54,12 @@ const Profile = () => {
           <p>의견 보내기</p>
         </button>
         <Divider color="bg-gray-300" margin="my-[1.6rem]" />
-        <button type="button" aria-label="로그아웃" className="cap_14_m py-[0.8rem] text-gray-800">
+        <button
+          type="button"
+          onClick={() => logout()}
+          aria-label="로그아웃"
+          className="cap_14_m py-[0.8rem] text-gray-800"
+        >
           <p>로그아웃</p>
         </button>
       </section>

--- a/src/pages/profile/profile.tsx
+++ b/src/pages/profile/profile.tsx
@@ -13,10 +13,6 @@ const Profile = () => {
 
   const { mutate: logout } = useMutation(userMutations.LOGOUT());
 
-  const handleClick = (link: string) => {
-    window.open(link, '_blank', 'noopener,noreferrer');
-  };
-
   if (!data) return null;
 
   return (
@@ -38,22 +34,24 @@ const Profile = () => {
       </div>
       <Divider thickness={0.4} color="bg-gray-200" />
       <section className="w-full flex-col items-start px-[1.6rem]">
-        <button
-          type="button"
+        <a
+          href={REQUEST_LINK}
+          target="_blank"
+          rel="noopener noreferrer"
           aria-label="문의하기"
           className="cap_14_m py-[0.8rem] text-gray-800"
-          onClick={() => handleClick(REQUEST_LINK)}
         >
-          <p>문의하기</p>
-        </button>
-        <button
-          type="button"
+          문의하기
+        </a>
+        <a
+          href={FEEDBACK_LINK}
+          target="_blank"
+          rel="noopener noreferrer"
           aria-label="의견 보내기"
           className="cap_14_m py-[0.8rem] text-gray-800"
-          onClick={() => handleClick(FEEDBACK_LINK)}
         >
-          <p>의견 보내기</p>
-        </button>
+          의견 보내기
+        </a>
         <Divider color="bg-gray-300" margin="my-[1.6rem]" />
         <button
           type="button"

--- a/src/pages/profile/profile.tsx
+++ b/src/pages/profile/profile.tsx
@@ -9,6 +9,10 @@ import { useQuery } from '@tanstack/react-query';
 const Profile = () => {
   const { data } = useQuery(userQueries.USER_INFO());
 
+  const handleClick = (link: string) => {
+    window.open(link, '_blank', 'noopener,noreferrer');
+  };
+
   if (!data) return null;
 
   return (
@@ -29,6 +33,28 @@ const Profile = () => {
         <Button size="L" label="프로필 · 매칭 조건 수정" />
       </div>
       <Divider thickness={0.4} color="bg-gray-200" />
+      <section className="w-full flex-col items-start px-[1.6rem]">
+        <button
+          type="button"
+          aria-label="문의하기"
+          className="cap_14_m py-[0.8rem] text-gray-800"
+          onClick={() => handleClick('https://notion')}
+        >
+          <p>문의하기</p>
+        </button>
+        <button
+          type="button"
+          aria-label="의견 보내기"
+          className="cap_14_m py-[0.8rem] text-gray-800"
+          onClick={() => handleClick('https://notion')}
+        >
+          <p>의견 보내기</p>
+        </button>
+        <Divider color="bg-gray-300" margin="my-[1.6rem]" />
+        <button type="button" aria-label="로그아웃" className="cap_14_m py-[0.8rem] text-gray-800">
+          <p>로그아웃</p>
+        </button>
+      </section>
       <Footer />
     </div>
   );

--- a/src/shared/apis/user/user-mutations.ts
+++ b/src/shared/apis/user/user-mutations.ts
@@ -1,6 +1,7 @@
 import { post } from '@apis/base/http';
 import { END_POINT } from '@constants/api';
 import { USER_KEY } from '@constants/query-key';
+import queryClient from '@libs/query-client';
 import { mutationOptions } from '@tanstack/react-query';
 import type { responseTypes } from '@/shared/types/base-types';
 import type { postUserInfoNicknameRequest, postUserInfoRequest } from '@/shared/types/user-types';
@@ -22,8 +23,10 @@ export const userMutations = {
     mutationOptions<responseTypes, Error, void>({
       mutationKey: USER_KEY.LOGOUT(),
       mutationFn: () => post(END_POINT.POST_AUTH_LOGOUT),
-      onSuccess: () => {
-        window.location.reload();
+      onSuccess: async () => {
+        await queryClient.cancelQueries({ queryKey: USER_KEY.ALL });
+
+        queryClient.removeQueries({ queryKey: USER_KEY.ALL });
       },
     }),
 };

--- a/src/shared/apis/user/user-mutations.ts
+++ b/src/shared/apis/user/user-mutations.ts
@@ -17,4 +17,10 @@ export const userMutations = {
       mutationKey: USER_KEY.INFO(),
       mutationFn: ({ gender, birthYear }) => post(END_POINT.USER_INFO, { gender, birthYear }),
     }),
+
+  LOGOUT: () =>
+    mutationOptions<responseTypes, Error, void>({
+      mutationKey: USER_KEY.LOGOUT(),
+      mutationFn: () => post(END_POINT.POST_AUTH_LOGOUT),
+    }),
 };

--- a/src/shared/apis/user/user-mutations.ts
+++ b/src/shared/apis/user/user-mutations.ts
@@ -28,5 +28,8 @@ export const userMutations = {
 
         queryClient.removeQueries({ queryKey: USER_KEY.ALL });
       },
+      onError: (err) => {
+        console.error('로그아웃 실패', err)
+      }
     }),
 };

--- a/src/shared/apis/user/user-mutations.ts
+++ b/src/shared/apis/user/user-mutations.ts
@@ -29,7 +29,7 @@ export const userMutations = {
         queryClient.removeQueries({ queryKey: USER_KEY.ALL });
       },
       onError: (err) => {
-        console.error('로그아웃 실패', err)
-      }
+        console.error('로그아웃 실패', err);
+      },
     }),
 };

--- a/src/shared/apis/user/user-mutations.ts
+++ b/src/shared/apis/user/user-mutations.ts
@@ -22,5 +22,8 @@ export const userMutations = {
     mutationOptions<responseTypes, Error, void>({
       mutationKey: USER_KEY.LOGOUT(),
       mutationFn: () => post(END_POINT.POST_AUTH_LOGOUT),
+      onSuccess: () => {
+        window.location.reload();
+      },
     }),
 };

--- a/src/shared/components/card/match-card/styles/card-variants.ts
+++ b/src/shared/components/card/match-card/styles/card-variants.ts
@@ -9,7 +9,7 @@ export const cardVariants = cva('relative w-full rounded-[12px] bg-white', {
       user: 'p-[2rem] shadow-1',
     },
     color: {
-      active: 'bg-main-200 outline outline-[1px] outline-main-600',
+      active: 'bg-main-200 outline outline-main-600',
       inactive: 'bg-white',
     },
   },

--- a/src/shared/components/divider/divider.tsx
+++ b/src/shared/components/divider/divider.tsx
@@ -2,16 +2,16 @@ import clsx from 'clsx';
 
 interface DividerProps {
   direction?: 'horizontal' | 'vertical';
-  color?: string;
-  thickness?: string;
-  margin?: string;
+  color?: string; // tailwind 클래스 ex: bg-gray-200
+  thickness?: number; // rem 단위 숫자 ex: 0.1 -> 0.1rem
+  margin?: string; // tailwind 마진 클래스
   className?: string;
 }
 
 const Divider = ({
   direction = 'horizontal',
   color = 'bg-gray-200',
-  thickness,
+  thickness = 0.1,
   margin,
   className,
 }: DividerProps) => {
@@ -20,12 +20,11 @@ const Divider = ({
   return (
     <div
       className={clsx(
-        isHorizontal
-          ? `w-full ${thickness || 'h-px'} ${margin || 'my-4'}`
-          : `h-full ${thickness || 'w-px'} ${margin || 'mx-4'}`,
+        isHorizontal ? `w-full ${margin || 'my-4'}` : `h-full ${margin || 'mx-4'}`,
         color,
         className,
       )}
+      style={isHorizontal ? { height: `${thickness}rem` } : { width: `${thickness}rem` }}
     />
   );
 };

--- a/src/shared/components/divider/divider.tsx
+++ b/src/shared/components/divider/divider.tsx
@@ -1,0 +1,33 @@
+import clsx from 'clsx';
+
+interface DividerProps {
+  direction?: 'horizontal' | 'vertical';
+  color?: string;
+  thickness?: string;
+  margin?: string;
+  className?: string;
+}
+
+const Divider = ({
+  direction = 'horizontal',
+  color = 'bg-gray-200',
+  thickness,
+  margin,
+  className,
+}: DividerProps) => {
+  const isHorizontal = direction === 'horizontal';
+
+  return (
+    <div
+      className={clsx(
+        isHorizontal
+          ? `w-full ${thickness || 'h-px'} ${margin || 'my-4'}`
+          : `h-full ${thickness || 'w-px'} ${margin || 'mx-4'}`,
+        color,
+        className,
+      )}
+    />
+  );
+};
+
+export default Divider;

--- a/src/shared/components/footer/constants/legal.ts
+++ b/src/shared/components/footer/constants/legal.ts
@@ -1,6 +1,1 @@
-export const MATCHING_PLATFORM_NOTICE = `※ 메잇볼은 고객 간의 야구 직관 메이트 매칭을 중개하는 플랫폼으로,
-직접적인 만남이나 거래에 개입하지 않으며, 이에 대한 책임을 지지
-않습니다.
-이용자 간 약속 및 행동에 대한 주의가 필요합니다.`;
-
 export const COPYRIGHT_NOTICE = '© 2025 MateBall. All rights reserved.';

--- a/src/shared/components/footer/footer.tsx
+++ b/src/shared/components/footer/footer.tsx
@@ -1,4 +1,4 @@
-import { COPYRIGHT_NOTICE, MATCHING_PLATFORM_NOTICE } from '@components/footer/constants/legal';
+import { COPYRIGHT_NOTICE } from '@components/footer/constants/legal';
 import Icon from '@components/icon/icon';
 import { EXTERNAL_LINKS } from '@constants/links';
 import { ROUTES } from '@routes/routes-config';
@@ -12,7 +12,7 @@ const Footer = () => {
 
   return (
     <footer
-      className={clsx('cap_12_m w-full flex-col gap-[4.8rem] px-[1.6rem] py-[3.2rem]', {
+      className={clsx('cap_12_m w-full flex-col gap-[2.4rem] px-[1.6rem] py-[3.2rem]', {
         'bg-gray-200': isHome,
       })}
     >
@@ -24,7 +24,6 @@ const Footer = () => {
         </div>
       </div>
       <div className="flex-col gap-[0.8rem] text-gray-600">
-        <p className="whitespace-pre-line">{MATCHING_PLATFORM_NOTICE}</p>
         <div className="flex-row gap-[0.8rem] py-[0.4rem]">
           <a
             href={EXTERNAL_LINKS.PRIVACY_POLICY}

--- a/src/shared/components/header/utils/get-header.tsx
+++ b/src/shared/components/header/utils/get-header.tsx
@@ -60,7 +60,7 @@ export const getHeaderContent = (
   }
 
   if (pathname === ROUTES.PROFILE) {
-    return <h1 className="head_20_sb text-gray-black">내 정보</h1>;
+    return <h1 className="head_20_sb text-gray-black">마이페이지</h1>;
   }
 
   if (pathname === ROUTES.CHAT) {

--- a/src/shared/constants/api.ts
+++ b/src/shared/constants/api.ts
@@ -5,6 +5,9 @@ export const END_POINT = {
   POST_AUTH_LOGIN: '/auth/login?code=',
   GET_USER_STATUS: '/v1/users/info-check',
 
+  // 로그아웃
+  POST_AUTH_LOGOUT: '/auth/logout',
+
   // 유저 관련
   GET_KAKAO_INFO: '/v1/users/kakao/info',
   USER_INFO: '/v1/users/info',

--- a/src/shared/constants/query-key.ts
+++ b/src/shared/constants/query-key.ts
@@ -5,6 +5,7 @@ export const USER_KEY = {
   KAKAO: () => [...USER_KEY.ALL, 'kakao'] as const,
   INFO: () => [...USER_KEY.ALL, 'info'] as const,
   NICKNAME: () => [...USER_KEY.ALL, 'nickname'] as const,
+  LOGOUT: () => [...USER_KEY.ALL, 'logout'] as const,
 } as const;
 
 export const AUTH_KEY = {


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #305 

## 💎 PR Point
- footer 디자인 수정
- 내정보 -> 마이페이지로 변경
- 문의하기, 의견보내기 메뉴 추가, 클릭시 새 탭으로 각각의 링크로 이동합니다.
- 로그아웃 메뉴 추가 및 api 연결했습니다. 로그아웃 버튼 클릭시 cookie에 저장되어있던 accessToken, refreshToken이 없어집니다.
- Divider 컴포넌트 추가

```ts
        <Divider color="bg-gray-300" margin="my-[1.6rem]" />
```

위에처럼 사용가능하고, 색상, 마진, 두께, 방향 지정가능해요 (입력안해도 기본값 설정되어있음, 가로, 0.1rem)

## 📸 Screenshot

https://github.com/user-attachments/assets/8eb8b2cb-3174-4ab4-aecd-b24b75e1a2cd



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 마이페이지에 로그아웃 버튼 추가
  - 문의하기·의견 보내기 외부 링크 버튼 추가
  - 프로필 화면에 구분선(Divider)으로 섹션 분리

- Style
  - 헤더 타이틀을 “내 정보”에서 “마이페이지”로 변경
  - 프로필·매칭 카드 그림자 제거 및 활성 스타일 미세 조정
  - 버튼 문구를 “프로필 · 매칭 조건 수정”으로 변경
  - 푸터 간격 축소 및 플랫폼 고지 문구 제거
<!-- end of auto-generated comment: release notes by coderabbit.ai -->