### PR TITLE
feat: SP1 매칭 성사 캡션 문구 수정 및 오픈채팅방 링크 연결

### DIFF
--- a/src/pages/result/components/matching-success-view.tsx
+++ b/src/pages/result/components/matching-success-view.tsx
@@ -32,7 +32,8 @@ const MatchingSuccessView = ({ isGroupMatching }: MatchingSuccessViewProps) => {
           </div>
         </div>
         <p className="body_16_m z-[var(--z-card-profile-4)] text-center text-gray-600">
-          이제 메이트와 소통할 수 있어요! <br />첫 인사를 건네볼까요?
+          이제 메이트와 소통할 수 있어요. <br />
+          채팅방에서는 기본 예의와 매너를 지켜주세요.
         </p>
       </div>
       <div className="w-full flex-row-center gap-[0.8rem] p-[1.6rem]">

--- a/src/pages/result/components/matching-success-view.tsx
+++ b/src/pages/result/components/matching-success-view.tsx
@@ -1,22 +1,69 @@
+import { matchQueries } from '@apis/match/match-queries';
 import Button from '@components/button/button/button';
 import { LOTTIE_PATH } from '@constants/lotties';
 import usePreventBackNavigation from '@hooks/use-prevent-back-navigation';
 import { MATCHING_SUCCESS_TITLE } from '@pages/match/constants/matching';
 import { ROUTES } from '@routes/routes-config';
+import { useQuery } from '@tanstack/react-query';
 import { Lottie } from '@toss/lottie';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useState } from 'react';
+import { useParams, useSearchParams } from 'react-router-dom';
 
 interface MatchingSuccessViewProps {
   isGroupMatching: boolean;
 }
 
 const MatchingSuccessView = ({ isGroupMatching }: MatchingSuccessViewProps) => {
-  const navigate = useNavigate();
   const [params] = useSearchParams();
-  const cardType = params.get('cardtype');
-  usePreventBackNavigation(
-    `${ROUTES.MATCH}?tab=${cardType === 'group' ? '그룹' : '1:1'}&filter=전체`,
-  );
+  const { id, matchId: matchIdParam } = useParams<{ id?: string; matchId?: string }>();
+  const [clicking, setClicking] = useState(false);
+
+  const tab = isGroupMatching ? 'group' : 'single';
+  const matchIdFromPath = Number(id ?? matchIdParam ?? '');
+  const matchIdFromQuery = Number(params.get('matchId') ?? '');
+  const matchId = Number.isFinite(matchIdFromPath) ? matchIdFromPath : matchIdFromQuery;
+
+  usePreventBackNavigation(`${ROUTES.MATCH}?tab=${tab}&filter=전체`);
+
+  const {
+    data: openChatRes,
+    isLoading: isUrlLoading,
+    isError,
+  } = useQuery({
+    ...matchQueries.OPEN_CHAT_URL(matchId),
+    staleTime: 0,
+  });
+
+  const openChatUrl =
+    openChatRes?.data?.chattingUrl && typeof openChatRes.data.chattingUrl === 'string'
+      ? openChatRes.data.chattingUrl.trim()
+      : '';
+
+  const normalizeUrl = (url: string) => (/^https?:\/\//i.test(url) ? url : `https://${url}`);
+
+  const openExternal: (url: string) => void = (() => {
+    let opening = false;
+    return (url: string) => {
+      if (opening) return;
+      opening = true;
+
+      const finalUrl = normalizeUrl(url);
+      window.open(finalUrl, '_blank', 'noopener,noreferrer');
+
+      window.setTimeout(() => {
+        opening = false;
+      }, 800);
+    };
+  })();
+
+  const handleEnterChatClick = (): void => {
+    if (!openChatUrl) return;
+    setClicking(true);
+    openExternal(openChatUrl);
+    window.setTimeout(() => setClicking(false), 300);
+  };
+
+  const disabled = isUrlLoading || isError || clicking || !openChatUrl;
 
   return (
     <div className="h-full flex-col-between">
@@ -24,6 +71,7 @@ const MatchingSuccessView = ({ isGroupMatching }: MatchingSuccessViewProps) => {
         <h2 className="title_24_sb z-[var(--z-card-profile-4)] mb-[20rem] text-center">
           {isGroupMatching ? MATCHING_SUCCESS_TITLE.group : MATCHING_SUCCESS_TITLE.single}
         </h2>
+
         <div className="fixed top-[17rem]">
           <div className="matching-success-background" />
           <div className="matching-lottie-gradient" />
@@ -31,16 +79,19 @@ const MatchingSuccessView = ({ isGroupMatching }: MatchingSuccessViewProps) => {
             <Lottie src={LOTTIE_PATH.SUCCESS} loop className="w-[16rem]" />
           </div>
         </div>
+
         <p className="body_16_m z-[var(--z-card-profile-4)] text-center text-gray-600">
           이제 메이트와 소통할 수 있어요. <br />
           채팅방에서는 기본 예의와 매너를 지켜주세요.
         </p>
       </div>
+
       <div className="w-full flex-row-center gap-[0.8rem] p-[1.6rem]">
         <Button
           label="채팅방 입장하기"
           className="w-full"
-          onClick={() => navigate(ROUTES.CHAT_ROOM)}
+          disabled={disabled}
+          onClick={handleEnterChatClick}
         />
       </div>
     </div>

--- a/src/pages/result/constants/matching-result.ts
+++ b/src/pages/result/constants/matching-result.ts
@@ -9,3 +9,5 @@ export const MATCHING_HEADER_MESSAGE = {
   },
 };
 export const ERROR_MESSAGE = '매칭 정보를 불러올 수 없습니다.\n다른 매칭으로 확인해 주세요.';
+
+export const ENTER_CHAT_COOLDOWN_MS = 800;

--- a/src/pages/result/utils/number.ts
+++ b/src/pages/result/utils/number.ts
@@ -1,0 +1,1 @@
+export const parseId = (v?: string | null) => (v && /^\d+$/.test(v) ? Number(v) : NaN);

--- a/src/pages/result/utils/url.ts
+++ b/src/pages/result/utils/url.ts
@@ -1,7 +1,6 @@
-export function normalizeUrl(url: string): string {
-  return /^https?:\/\//i.test(url) ? url : `https://${url}`;
-}
+export const normalizeUrl = (url: string): string =>
+  /^https?:\/\//i.test(url) ? url : `https://${url}`;
 
-export function openExternal(url: string): void {
+export const openExternal = (url: string): void => {
   window.open(normalizeUrl(url), '_blank', 'noopener,noreferrer');
-}
+};

--- a/src/pages/result/utils/url.ts
+++ b/src/pages/result/utils/url.ts
@@ -1,0 +1,7 @@
+export function normalizeUrl(url: string): string {
+  return /^https?:\/\//i.test(url) ? url : `https://${url}`;
+}
+
+export function openExternal(url: string): void {
+  window.open(normalizeUrl(url), '_blank', 'noopener,noreferrer');
+}

--- a/src/shared/apis/match/match-queries.ts
+++ b/src/shared/apis/match/match-queries.ts
@@ -8,6 +8,7 @@ import type {
   getGroupMatchResultResponse,
   getMatchCountResponse,
   getMatchDetailResponse,
+  getOpenChatUrlResponse,
   getSingleMatchListResponse,
   getSingleMatchResultResponse,
   getSingleMatchStatusResponse,
@@ -90,5 +91,15 @@ export const matchQueries = {
         const url = `${END_POINT.GET_MATCH_DETAIL(matchId)}${typeof newRequest !== 'undefined' ? `?newRequest=${newRequest}` : ''}`;
         return get(url);
       },
+    }),
+
+  /**
+   * 오픈채팅방 주소 조회
+   */
+  OPEN_CHAT_URL: (matchId: number, enabled = true) =>
+    queryOptions<getOpenChatUrlResponse>({
+      queryKey: MATCH_KEY.OPEN_CHAT(matchId),
+      queryFn: () => get(END_POINT.GET_OPEN_CHAT_URL(matchId)),
+      enabled,
     }),
 };

--- a/src/shared/apis/match/match-queries.ts
+++ b/src/shared/apis/match/match-queries.ts
@@ -8,7 +8,6 @@ import type {
   getGroupMatchResultResponse,
   getMatchCountResponse,
   getMatchDetailResponse,
-  getOpenChatUrlResponse,
   getSingleMatchListResponse,
   getSingleMatchResultResponse,
   getSingleMatchStatusResponse,
@@ -97,7 +96,7 @@ export const matchQueries = {
    * 오픈채팅방 주소 조회
    */
   OPEN_CHAT_URL: (matchId: number, enabled = true) =>
-    queryOptions<getOpenChatUrlResponse>({
+    queryOptions<{ chattingUrl: string }>({
       queryKey: MATCH_KEY.OPEN_CHAT(matchId),
       queryFn: () => get(END_POINT.GET_OPEN_CHAT_URL(matchId)),
       enabled,

--- a/src/shared/constants/api.ts
+++ b/src/shared/constants/api.ts
@@ -33,4 +33,5 @@ export const END_POINT = {
   PATCH_MATCH_STAGE: (matchId: number | string) => `/v1/users/match-stage/${matchId}`,
   POST_MATCH_NEW_REQUEST: (matchId: number | string) =>
     `/v1/users/match/${matchId}?newRequest=true`,
+  GET_OPEN_CHAT_URL: (matchId: number | string) => `/v2/users/match/${matchId}/chatting`,
 };

--- a/src/shared/constants/query-key.ts
+++ b/src/shared/constants/query-key.ts
@@ -52,5 +52,5 @@ export const MATCH_KEY = {
   USERS_NUM_COUNT: (matchId: number) => [...MATCH_KEY.ALL, 'usersNumCount', matchId] as const,
   PATCH_STAGE: (key?: string) => [...MATCH_KEY.ALL, 'patch', 'stage', key] as const,
 
-  OPEN_CHAT: (matchId: number) => ['match', 'open-chat', matchId],
+  OPEN_CHAT: (matchId: number) => [...MATCH_KEY.ALL, 'open-chat', matchId] as const,
 } as const;

--- a/src/shared/constants/query-key.ts
+++ b/src/shared/constants/query-key.ts
@@ -51,4 +51,6 @@ export const MATCH_KEY = {
   DETAIL: (matchId: number) => [...MATCH_KEY.ALL, 'detail', matchId] as const,
   USERS_NUM_COUNT: (matchId: number) => [...MATCH_KEY.ALL, 'usersNumCount', matchId] as const,
   PATCH_STAGE: (key?: string) => [...MATCH_KEY.ALL, 'patch', 'stage', key] as const,
+
+  OPEN_CHAT: (matchId: number) => ['match', 'open-chat', matchId],
 } as const;

--- a/src/shared/types/match-types.ts
+++ b/src/shared/types/match-types.ts
@@ -229,3 +229,15 @@ export interface getMatchDetailResponse {
   nickname: string;
   mates: matchDetailMateSimple[];
 }
+
+/**
+ * 오픈채팅방 주소 조회
+ * get
+ * /v2/users/match/{matchId}/chatting
+ */
+
+export interface getOpenChatUrlResponse {
+  status: number;
+  message: string;
+  data: { chattingUrl: string };
+}


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #312

## 💎 PR Point

매칭 성사 화면 캡션 문구를 수정하였습니다.
오픈 채팅방 링크를 조회하여 이동하는 로직을 추가했습니다.

### 수정 전
이제 메이트와 소통할 수 있어요!
첫 인사를 건네볼까요?

### 수정 후
이제 메이트와 소통할 수 있어요.
채팅방에서는 기본 예의와 매너를 지켜주세요.

## 📸 Screenshot
<img width="300" alt="image" src="https://github.com/user-attachments/assets/fe7a1499-bccf-47aa-a7f8-17b74963f27d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 매칭 성공 화면에서 '채팅 입장' 버튼이 외부 오픈채팅을 새 탭으로 안전하게 여는 동작으로 변경되었고, 로딩·오류·중복 클릭 시 비활성화됩니다.
- **Style**
  - 안내 문구를 "이제 메이트와 소통할 수 있어요. 채팅방에서는 기본 예의와 매너를 지켜주세요."로 업데이트해 가독성을 높였습니다.
- **Chores**
  - 외부 채팅 URL 조회 연동, URL 정규화·안전 오픈 및 클릭 쿨다운(중복 방지)·ID 파싱 지원을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->