### PR TITLE
feat: SP1 그룹 매칭 수락 완료 화면 수정

### DIFF
--- a/src/pages/result/components/matching-agree-view.tsx
+++ b/src/pages/result/components/matching-agree-view.tsx
@@ -39,11 +39,6 @@ const MatchingAgreeView = ({ matchId }: MatchingAgreeViewProps) => {
         </p>
       </div>
       <div className="w-full flex-row-center gap-[0.8rem] p-[1.6rem]">
-        <Button
-          label="메이트 더 찾아보기"
-          variant="skyblue"
-          onClick={() => navigate(ROUTES.HOME)}
-        />
         <Button label="매칭 현황 보기" onClick={() => navigate(ROUTES.MATCH)} />
       </div>
     </div>


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #314

## 💎 PR Point

기존 그룹 매칭 수락 완료 화면은 버튼이 두 개였는데, 디자인 변경사항에 맞게 [메이트 더 찾아보기] 버튼을 삭제하였습니다.

## 📸 Screenshot

<img width="300" alt="image" src="https://github.com/user-attachments/assets/32ab9dd0-a4de-4191-bd5b-583d888f52b5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 결과 화면에서 하단 액션 버튼 ‘메이트 더 찾아보기’를 제거하여 인터페이스를 단순화했습니다. 해당 버튼의 홈 이동 경로도 함께 사라졌습니다.
  - 이제 화면에는 ‘매칭 현황 보기’ 버튼만 노출되며, 동작은 기존과 동일합니다. 그 외 기능 동작, 데이터 처리, 네비게이션 흐름에는 변경이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->