### PR TITLE
feat: SP1 회원가입, 약관동의 api 연결

### DIFF
--- a/src/pages/edit-profile/components/selection-group.tsx
+++ b/src/pages/edit-profile/components/selection-group.tsx
@@ -1,0 +1,49 @@
+import Button from '@components/button/button/button';
+import { cn } from '@libs/cn';
+
+interface SelectionGroupProps {
+  title: string;
+  options: { id: number; label: string }[] | string[];
+  selectedValue: string;
+  onSelect: (value: string) => void;
+  disabled?: boolean;
+}
+
+const SelectionGroup = ({
+  title,
+  options,
+  selectedValue,
+  onSelect,
+  disabled,
+}: SelectionGroupProps) => {
+  return (
+    <div className="flex-col gap-[1.6rem]">
+      <p className="body_16_m">{title}</p>
+      <div className="flex flex-wrap gap-[0.8rem]">
+        {options.map((option) => {
+          const key = typeof option === 'string' ? option : option.id;
+          const label = typeof option === 'string' ? option : option.label;
+          const isSelected = selectedValue === label;
+
+          return (
+            <Button
+              key={key}
+              label={label}
+              variant={disabled ? 'disabled' : isSelected ? 'skyblue' : 'gray2'}
+              className={cn(
+                'cap_14_sb w-auto px-[1.6rem] py-[0.6rem]',
+                disabled && 'cursor-not-allowed',
+              )}
+              onClick={() => {
+                if (disabled) return;
+                onSelect(label);
+              }}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default SelectionGroup;

--- a/src/pages/edit-profile/constants/edit-profile.ts
+++ b/src/pages/edit-profile/constants/edit-profile.ts
@@ -1,0 +1,1 @@
+export const PROFILE_SYNC_MATE = ['같은 팀 메이트', '상관없어요'];

--- a/src/pages/edit-profile/edit-profile.tsx
+++ b/src/pages/edit-profile/edit-profile.tsx
@@ -1,0 +1,153 @@
+import Button from '@components/button/button/button';
+import Divider from '@components/divider/divider';
+import Input from '@components/input/input';
+import { cn } from '@libs/cn';
+import SelectionGroup from '@pages/edit-profile/components/selection-group';
+import { PROFILE_SYNC_MATE } from '@pages/edit-profile/constants/edit-profile';
+import { mockEditData } from '@pages/edit-profile/mocks/mockEditData';
+import {
+  GENDER,
+  NO_TEAM_OPTION,
+  TEAMS,
+  VIEWING_STYLE,
+} from '@pages/onboarding/constants/onboarding';
+import { INFORMATION_RULE_MESSAGE, NICKNAME_RULE_MESSAGE } from '@pages/sign-up/constants/NOTICE';
+import { INFORMATION_PLACEHOLDER, NICKNAME_PLACEHOLDER } from '@pages/sign-up/constants/validation';
+import { useMemo, useRef, useState } from 'react';
+
+const EditProfile = () => {
+  const [team, setTeam] = useState(mockEditData.team);
+  const [gender, setGender] = useState(mockEditData.genderPreference);
+  const [mateTeam, setMateTeam] = useState(mockEditData.teamAllowed || '상관없어요');
+  const [viewStyle, setViewStyle] = useState(mockEditData.style);
+  const [isSubmit, setIsSubmit] = useState(false);
+
+  const initialValue = useRef({
+    team: mockEditData.team,
+    gender: mockEditData.genderPreference,
+    mateTeam: mockEditData.teamAllowed,
+    viewStyle: mockEditData.style,
+  });
+
+  const isDirty = useMemo(() => {
+    const init = initialValue.current;
+
+    return (
+      team !== init.team ||
+      gender !== init.gender ||
+      mateTeam !== init.mateTeam ||
+      viewStyle !== init.viewStyle
+    );
+  }, [team, gender, mateTeam, viewStyle]);
+
+  const isSubmitDisabled = !isDirty || isSubmit;
+
+  const handleSaveClick = () => {
+    if (!isDirty) return;
+
+    setIsSubmit(true);
+
+    // TODO: 실제 API 호출
+  };
+
+  return (
+    <div className="h-full bg-gray-white px-[1.6rem] pt-[1.6rem] pb-[4rem]">
+      <h2 className="subhead_18_sb mb-[1.6rem]">프로필 수정</h2>
+      <section>
+        <Input
+          placeholder={NICKNAME_PLACEHOLDER}
+          label="닉네임"
+          defaultMessage={NICKNAME_RULE_MESSAGE}
+        />
+        <div className="mb-[2.5rem] flex justify-end">
+          <Button label="수정" className="cap_14_sb mt-[0.8rem] w-auto px-[1.6rem] py-[0.6rem]" />
+        </div>
+
+        <Input
+          placeholder={INFORMATION_PLACEHOLDER}
+          defaultMessage={INFORMATION_RULE_MESSAGE}
+          length={0}
+          hasLength
+          className="h-[10.4rem]"
+          label="한 줄 소개"
+          multiline
+        />
+        <div className="flex justify-end">
+          <Button label="수정" className="cap_14_sb mt-[0.8rem] w-auto px-[1.6rem] py-[0.6rem]" />
+        </div>
+      </section>
+
+      <div className="-mx-[1.6rem] my-[3.2rem]">
+        <Divider thickness={0.4} />
+      </div>
+
+      <section className="flex-col pb-[5.6rem]">
+        <h2 className="subhead_18_sb mb-[0.4rem]">매칭 조건 수정</h2>
+        <p className="cap_12_m mb-[1.6rem] text-gray-500">
+          수정한 조건을 기반으로 새로운 메이트를 추천해드려요!
+        </p>
+
+        <div className="flex-col gap-[3.2rem]">
+          <div className="flex-col gap-[1.6rem]">
+            <p className="body_16_m">응원팀</p>
+            <div className="flex flex-wrap gap-[0.8rem]">
+              {TEAMS.map((option) => {
+                const selected = team === option;
+                return (
+                  <Button
+                    key={option}
+                    label={option}
+                    variant={selected ? 'skyblue' : 'gray2'}
+                    className="cap_14_sb w-auto px-[1.6rem] py-[0.6rem] text-gray-900"
+                    onClick={() => setTeam(option)}
+                  />
+                );
+              })}
+              <Button
+                label={NO_TEAM_OPTION}
+                variant={team === NO_TEAM_OPTION ? 'skyblue' : 'gray2'}
+                className="cap_14_sb w-fit px-[1.6rem] py-[0.6rem] "
+                onClick={() => {
+                  setTeam(NO_TEAM_OPTION);
+                  setMateTeam('상관없어요');
+                }}
+              />
+            </div>
+          </div>
+
+          <SelectionGroup
+            title="직관 메이트의 응원팀"
+            options={PROFILE_SYNC_MATE}
+            selectedValue={mateTeam}
+            onSelect={setMateTeam}
+            disabled={team === NO_TEAM_OPTION}
+          />
+
+          <SelectionGroup
+            title="관람 스타일"
+            options={VIEWING_STYLE}
+            selectedValue={viewStyle}
+            onSelect={setViewStyle}
+          />
+
+          <SelectionGroup
+            title="선호 성별"
+            options={GENDER}
+            selectedValue={gender}
+            onSelect={setGender}
+          />
+        </div>
+      </section>
+
+      <Button
+        variant={isSubmitDisabled ? 'disabled' : 'blue'}
+        className={cn(isSubmitDisabled && 'cursor-not-allowed')}
+        onClick={handleSaveClick}
+        label="매칭 조건 수정"
+        ariaLabel="매칭 조건 수정"
+      />
+    </div>
+  );
+};
+
+export default EditProfile;

--- a/src/pages/edit-profile/edit-profile.tsx
+++ b/src/pages/edit-profile/edit-profile.tsx
@@ -11,8 +11,11 @@ import {
   TEAMS,
   VIEWING_STYLE,
 } from '@pages/onboarding/constants/onboarding';
-import { INFORMATION_RULE_MESSAGE, NICKNAME_RULE_MESSAGE } from '@pages/sign-up/constants/NOTICE';
-import { INFORMATION_PLACEHOLDER, NICKNAME_PLACEHOLDER } from '@pages/sign-up/constants/validation';
+import { INTRODUCTION_RULE_MESSAGE, NICKNAME_RULE_MESSAGE } from '@pages/sign-up/constants/NOTICE';
+import {
+  INTRODUCTION_PLACEHOLDER,
+  NICKNAME_PLACEHOLDER,
+} from '@pages/sign-up/constants/validation';
 import { useMemo, useRef, useState } from 'react';
 
 const EditProfile = () => {
@@ -64,8 +67,8 @@ const EditProfile = () => {
         </div>
 
         <Input
-          placeholder={INFORMATION_PLACEHOLDER}
-          defaultMessage={INFORMATION_RULE_MESSAGE}
+          placeholder={INTRODUCTION_PLACEHOLDER}
+          defaultMessage={INTRODUCTION_RULE_MESSAGE}
           length={0}
           hasLength
           className="h-[10.4rem]"

--- a/src/pages/edit-profile/mocks/mockEditData.ts
+++ b/src/pages/edit-profile/mocks/mockEditData.ts
@@ -1,0 +1,6 @@
+export const mockEditData = {
+  team: '응원하는 팀이 없어요.',
+  teamAllowed: '상관없어요',
+  style: '직관먹방러',
+  genderPreference: '여성',
+};

--- a/src/pages/profile/constants/link.ts
+++ b/src/pages/profile/constants/link.ts
@@ -1,0 +1,3 @@
+export const REQUEST_LINK = 'https://open.kakao.com/o/su2KJENh';
+
+export const FEEDBACK_LINK = 'https://smore.im/form/jlMGj3m0v3';

--- a/src/pages/profile/edit-profile/edit-profile.tsx
+++ b/src/pages/profile/edit-profile/edit-profile.tsx
@@ -1,5 +1,0 @@
-const EditProfile = () => {
-  return <div>내정보수정페이지</div>;
-};
-
-export default EditProfile;

--- a/src/pages/profile/profile.tsx
+++ b/src/pages/profile/profile.tsx
@@ -5,12 +5,15 @@ import Card from '@components/card/match-card/card';
 import type { ChipColor } from '@components/chip/chip-list';
 import Divider from '@components/divider/divider';
 import Footer from '@components/footer/footer';
+import { FEEDBACK_LINK, REQUEST_LINK } from '@pages/profile/constants/link';
+import { ROUTES } from '@routes/routes-config';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { FEEDBACK_LINK, REQUEST_LINK } from './constants/link';
+import { useNavigate } from 'react-router-dom';
 
 const Profile = () => {
-  const { data } = useQuery(userQueries.USER_INFO());
+  const navigate = useNavigate();
 
+  const { data } = useQuery(userQueries.USER_INFO());
   const { mutate: logout } = useMutation(userMutations.LOGOUT());
 
   if (!data) return null;
@@ -30,7 +33,11 @@ const Profile = () => {
           introduction={data.introduction ?? ''}
           chips={[(data.team ?? '') as ChipColor, (data.style ?? '') as ChipColor]}
         />
-        <Button size="L" label="프로필 · 매칭 조건 수정" />
+        <Button
+          size="L"
+          label="프로필 · 매칭 조건 수정"
+          onClick={() => navigate(ROUTES.PROFILE_EDIT)}
+        />
       </div>
       <Divider thickness={0.4} color="bg-gray-200" />
       <section className="w-full flex-col items-start px-[1.6rem]">

--- a/src/pages/profile/profile.tsx
+++ b/src/pages/profile/profile.tsx
@@ -1,12 +1,17 @@
+import { userMutations } from '@apis/user/user-mutations';
 import { userQueries } from '@apis/user/user-queries';
 import Button from '@components/button/button/button';
 import Card from '@components/card/match-card/card';
 import type { ChipColor } from '@components/chip/chip-list';
+import Divider from '@components/divider/divider';
 import Footer from '@components/footer/footer';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { FEEDBACK_LINK, REQUEST_LINK } from './constants/link';
 
 const Profile = () => {
   const { data } = useQuery(userQueries.USER_INFO());
+
+  const { mutate: logout } = useMutation(userMutations.LOGOUT());
 
   if (!data) return null;
 
@@ -14,6 +19,7 @@ const Profile = () => {
     <div className="h-full flex-col-between">
       <div className="w-full flex-col-center gap-[1.6rem] px-[1.6rem] pt-[1.6rem] pb-[5.6rem]">
         <Card
+          className="!shadow-none"
           type="user"
           nickname={data.nickname ?? ''}
           imgUrl={[data.imgUrl ?? '']}
@@ -24,8 +30,38 @@ const Profile = () => {
           introduction={data.introduction ?? ''}
           chips={[(data.team ?? '') as ChipColor, (data.style ?? '') as ChipColor]}
         />
-        <Button size="L" label="매칭 조건 재설정 하기" />
+        <Button size="L" label="프로필 · 매칭 조건 수정" />
       </div>
+      <Divider thickness={0.4} color="bg-gray-200" />
+      <section className="w-full flex-col items-start px-[1.6rem]">
+        <a
+          href={REQUEST_LINK}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="문의하기"
+          className="cap_14_m py-[0.8rem] text-gray-800"
+        >
+          문의하기
+        </a>
+        <a
+          href={FEEDBACK_LINK}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="의견 보내기"
+          className="cap_14_m py-[0.8rem] text-gray-800"
+        >
+          의견 보내기
+        </a>
+        <Divider color="bg-gray-300" margin="my-[1.6rem]" />
+        <button
+          type="button"
+          onClick={() => logout()}
+          aria-label="로그아웃"
+          className="cap_14_m cursor-pointer py-[0.8rem] text-gray-800"
+        >
+          <p>로그아웃</p>
+        </button>
+      </section>
       <Footer />
     </div>
   );

--- a/src/pages/sign-up/components/agreement-step.tsx
+++ b/src/pages/sign-up/components/agreement-step.tsx
@@ -1,6 +1,7 @@
 import Button from '@components/button/button/button';
 import Icon from '@components/icon/icon';
 import CheckboxRow from '@pages/sign-up/components/checkbox-row';
+import { PRIVACY_LINK, TERMS_LINK } from '@pages/sign-up/constants/LINK';
 import { useState } from 'react';
 
 interface AgreementStepProps {
@@ -51,6 +52,7 @@ const AgreementStep = ({ next }: AgreementStepProps) => {
             onClick={handleCheckTerms}
             checked={terms}
             svg={<Icon name="arrow-right-18" size={1.8} />}
+            link={TERMS_LINK}
           />
 
           <CheckboxRow
@@ -58,6 +60,7 @@ const AgreementStep = ({ next }: AgreementStepProps) => {
             onClick={handleCheckPrivacy}
             checked={privacy}
             svg={<Icon name="arrow-right-18" size={1.8} />}
+            link={PRIVACY_LINK}
           />
         </div>
         <div className="px-[1.6rem]">

--- a/src/pages/sign-up/components/checkbox-row.tsx
+++ b/src/pages/sign-up/components/checkbox-row.tsx
@@ -28,8 +28,7 @@ const CheckboxRow = ({ label, checked, onClick, svg, divider, className, link }:
         </button>
         <span className="body_16_m">{label}</span>
       </div>
-      <a href={link} className="cursor-pointer">
-        {' '}
+      <a href={link} className="cursor-pointer" target="_blank" rel="noopener noreferrer">
         {svg}
       </a>
     </button>

--- a/src/pages/sign-up/components/checkbox-row.tsx
+++ b/src/pages/sign-up/components/checkbox-row.tsx
@@ -14,8 +14,7 @@ interface CheckboxProps {
 
 const CheckboxRow = ({ label, checked, onClick, svg, divider, className, link }: CheckboxProps) => {
   return (
-    <button
-      type="button"
+    <div
       className={cn(
         'flex w-full items-center justify-between gap-[0.8rem] p-[0.8rem] px-[1.6rem] text-left',
         divider && 'border-gray-200 border-b',
@@ -31,7 +30,7 @@ const CheckboxRow = ({ label, checked, onClick, svg, divider, className, link }:
       <a href={link} className="cursor-pointer" target="_blank" rel="noopener noreferrer">
         {svg}
       </a>
-    </button>
+    </div>
   );
 };
 

--- a/src/pages/sign-up/components/checkbox-row.tsx
+++ b/src/pages/sign-up/components/checkbox-row.tsx
@@ -9,9 +9,10 @@ interface CheckboxProps {
   svg?: ReactNode;
   divider?: boolean;
   className?: string;
+  link?: string;
 }
 
-const CheckboxRow = ({ label, checked, onClick, svg, divider, className }: CheckboxProps) => {
+const CheckboxRow = ({ label, checked, onClick, svg, divider, className, link }: CheckboxProps) => {
   return (
     <button
       type="button"
@@ -27,7 +28,10 @@ const CheckboxRow = ({ label, checked, onClick, svg, divider, className }: Check
         </button>
         <span className="body_16_m">{label}</span>
       </div>
-      {svg}
+      <a href={link} className="cursor-pointer">
+        {' '}
+        {svg}
+      </a>
     </button>
   );
 };

--- a/src/pages/sign-up/components/signup-step.tsx
+++ b/src/pages/sign-up/components/signup-step.tsx
@@ -44,7 +44,7 @@ const SignupStep = () => {
   const isInformationValid = !errors.introduction && informationValue.length > 0;
 
   const userInfoMutation = useMutation(userMutations.USER_INFO());
-  const agreementInfoMutaion = useMutation(userMutations.AGREEEMENT_INFO());
+  const agreementInfoMutaion = useMutation(userMutations.AGREEMENT_INFO());
 
   const informationLength = informationValue.length ?? 0;
 

--- a/src/pages/sign-up/components/signup-step.tsx
+++ b/src/pages/sign-up/components/signup-step.tsx
@@ -57,8 +57,8 @@ const SignupStep = () => {
     };
 
     try {
-      await userInfoMutation.mutateAsync(userData);
       await agreementInfoMutaion.mutateAsync({ hasAccepted: true });
+      await userInfoMutation.mutateAsync(userData);
     } catch (e) {
       console.error('signup failed:', e);
     }

--- a/src/pages/sign-up/components/signup-step.tsx
+++ b/src/pages/sign-up/components/signup-step.tsx
@@ -44,17 +44,24 @@ const SignupStep = () => {
   const isInformationValid = !errors.introduction && informationValue.length > 0;
 
   const userInfoMutation = useMutation(userMutations.USER_INFO());
+  const agreementInfoMutaion = useMutation(userMutations.AGREEEMENT_INFO());
 
   const informationLength = informationValue.length ?? 0;
 
-  const onSubmit = (data: UserInfoFormValues) => {
+  const onSubmit = async (data: UserInfoFormValues) => {
     const userData: postUserInfoRequest = {
       nickname: data.nickname,
       introduction: data.introduction,
       birthYear: Number(data.birthYear),
       gender: data.gender,
     };
-    userInfoMutation.mutate(userData);
+
+    try {
+      await userInfoMutation.mutateAsync(userData);
+      await agreementInfoMutaion.mutateAsync({ hasAccepted: true });
+    } catch (e) {
+      console.error('signup failed:', e);
+    }
   };
 
   const { onBlur: onNicknameBlur, ref: nicknameRef, ...nicknameInputProps } = register('nickname');

--- a/src/pages/sign-up/components/signup-step.tsx
+++ b/src/pages/sign-up/components/signup-step.tsx
@@ -5,7 +5,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import {
   BIRTHYEAR_RULE_MESSAGE,
   BIRTHYEAR_SUCCESS_MESSAGE,
-  INFORMATION_RULE_MESSAGE,
+  INTRODUCTION_RULE_MESSAGE,
   NICKNAME_RULE_MESSAGE,
   NICKNAME_SUCCESS_MESSAGE,
   NICKNAME_TITLE,
@@ -105,7 +105,7 @@ const SignupStep = () => {
             placeholder={INTRODUCTION_PLACEHOLDER}
             className="h-[10.4rem]"
             label="한 줄 소개"
-            defaultMessage={INFORMATION_RULE_MESSAGE}
+            defaultMessage={INTRODUCTION_RULE_MESSAGE}
             multiline
             maxLength={INTRODUCTION_MAX_LENGTH}
             isError={!!errors.introduction}

--- a/src/pages/sign-up/constants/LINK.ts
+++ b/src/pages/sign-up/constants/LINK.ts
@@ -1,0 +1,3 @@
+export const TERMS_LINK = 'https://www.notion.so/22bebc583aa58015b71dd75cf7884d33?pvs=4';
+
+export const PRIVACY_LINK = 'https://www.notion.so/22bebc583aa580ce8c31eb0fbe84ac58?pvs=4';

--- a/src/pages/sign-up/constants/NOTICE.ts
+++ b/src/pages/sign-up/constants/NOTICE.ts
@@ -14,4 +14,4 @@ export const BIRTHYEAR_RULE_MESSAGE = '4자리 숫자만 입력 가능';
 
 export const BIRTHYEAR_SUCCESS_MESSAGE = '올바른 입력 값이에요.';
 
-export const INFORMATION_RULE_MESSAGE = '비방, 욕설 등 불쾌감을 줄 수 있는 내용 제한';
+export const INTRODUCTION_RULE_MESSAGE = '비방, 욕설 등 불쾌감을 줄 수 있는 내용 제한';

--- a/src/pages/sign-up/constants/validation.ts
+++ b/src/pages/sign-up/constants/validation.ts
@@ -22,7 +22,7 @@ export const NICKNAME_PLACEHOLDER = '2-6자 이내의 닉네임을 입력하세�
 
 export const BIRTH_PLACEHOLDER = 'YYYY 형태로 입력하세요.';
 
-export const INFORMATION_PLACEHOLDER =
+export const INTRODUCTION_PLACEHOLDER =
   '엘지팬입니다! 같이 응원가 떼창해요~\n잠실에서 김말국 먹으면서 직관하고 싶어요 ㅎㅎ';
 
 export const BIRTH_ERROR_MESSAGES = {
@@ -38,5 +38,5 @@ export const GENDER_OPTIONS = ['남성', '여성'] as const;
 
 export const SIGNUP_STEPS = ['AGREEMENT', 'INFORMATION'];
 
-export const INFORMATION_MIN_LENGTH = 1;
-export const INFORMATION_MAX_LENGTH = 50;
+export const INTRODUCTION_MIN_LENGTH = 1;
+export const INTRODUCTION_MAX_LENGTH = 50;

--- a/src/pages/sign-up/schema/validation-schema.ts
+++ b/src/pages/sign-up/schema/validation-schema.ts
@@ -2,8 +2,8 @@ import {
   BIRTH_ERROR_MESSAGES,
   GENDER_ERROR_MESSAGES,
   GENDER_OPTIONS,
-  INFORMATION_MAX_LENGTH,
-  INFORMATION_MIN_LENGTH,
+  INTRODUCTION_MAX_LENGTH,
+  INTRODUCTION_MIN_LENGTH,
   NICKNAME_ERROR_MESSAGES,
   NICKNAME_MAX_LENGTH,
   NICKNAME_MIN_LENGTH,
@@ -11,7 +11,7 @@ import {
 } from '@pages/sign-up/constants/validation';
 import { z } from 'zod';
 
-export const NicknameSchema = z.object({
+export const UserInfoSchema = z.object({
   nickname: z
     .string()
     .min(NICKNAME_MIN_LENGTH, { message: NICKNAME_ERROR_MESSAGES.LENGTH })
@@ -39,7 +39,7 @@ export const NicknameSchema = z.object({
   gender: z.enum(GENDER_OPTIONS, {
     required_error: GENDER_ERROR_MESSAGES.REQUIRED,
   }),
-  information: z.string().trim().min(INFORMATION_MIN_LENGTH).max(INFORMATION_MAX_LENGTH),
+  introduction: z.string().trim().min(INTRODUCTION_MIN_LENGTH).max(INTRODUCTION_MAX_LENGTH),
 });
 
-export type NicknameFormValues = z.infer<typeof NicknameSchema>;
+export type UserInfoFormValues = z.infer<typeof UserInfoSchema>;

--- a/src/shared/apis/user/user-mutations.ts
+++ b/src/shared/apis/user/user-mutations.ts
@@ -38,7 +38,7 @@ export const userMutations = {
       },
     }),
 
-  AGREEEMENT_INFO: () =>
+  AGREEMENT_INFO: () =>
     mutationOptions<responseTypes, Error, postAgreementInfoRequest>({
       mutationKey: USER_KEY.AGREEMENT(),
       mutationFn: ({ hasAccepted }) => post(END_POINT.AGREEMENT_INFO, { hasAccepted }),

--- a/src/shared/apis/user/user-mutations.ts
+++ b/src/shared/apis/user/user-mutations.ts
@@ -2,6 +2,9 @@ import { post } from '@apis/base/http';
 import { END_POINT } from '@constants/api';
 import { USER_KEY } from '@constants/query-key';
 import queryClient from '@libs/query-client';
+import { router } from '@routes/router';
+import { ROUTES } from '@routes/routes-config';
+
 import { mutationOptions } from '@tanstack/react-query';
 import type { responseTypes } from '@/shared/types/base-types';
 import type { postAgreementInfoRequest, postUserInfoRequest } from '@/shared/types/user-types';
@@ -12,6 +15,13 @@ export const userMutations = {
       mutationKey: USER_KEY.INFO(),
       mutationFn: ({ nickname, introduction, birthYear, gender }) =>
         post(END_POINT.USER_INFO, { nickname, introduction, birthYear, gender }),
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({ queryKey: USER_KEY.ALL });
+        router.navigate(ROUTES.HOME, { replace: true });
+      },
+      onError: (err) => {
+        console.error(err);
+      },
     }),
 
   LOGOUT: () =>

--- a/src/shared/apis/user/user-mutations.ts
+++ b/src/shared/apis/user/user-mutations.ts
@@ -1,6 +1,7 @@
 import { post } from '@apis/base/http';
 import { END_POINT } from '@constants/api';
 import { USER_KEY } from '@constants/query-key';
+import queryClient from '@libs/query-client';
 import { mutationOptions } from '@tanstack/react-query';
 import type { responseTypes } from '@/shared/types/base-types';
 import type { postUserInfoNicknameRequest, postUserInfoRequest } from '@/shared/types/user-types';
@@ -16,5 +17,19 @@ export const userMutations = {
     mutationOptions<responseTypes, Error, postUserInfoRequest>({
       mutationKey: USER_KEY.INFO(),
       mutationFn: ({ gender, birthYear }) => post(END_POINT.USER_INFO, { gender, birthYear }),
+    }),
+
+  LOGOUT: () =>
+    mutationOptions<responseTypes, Error, void>({
+      mutationKey: USER_KEY.LOGOUT(),
+      mutationFn: () => post(END_POINT.POST_AUTH_LOGOUT),
+      onSuccess: async () => {
+        await queryClient.cancelQueries({ queryKey: USER_KEY.ALL });
+
+        queryClient.removeQueries({ queryKey: USER_KEY.ALL });
+      },
+      onError: (err) => {
+        console.error('로그아웃 실패', err);
+      },
     }),
 };

--- a/src/shared/apis/user/user-mutations.ts
+++ b/src/shared/apis/user/user-mutations.ts
@@ -4,23 +4,14 @@ import { USER_KEY } from '@constants/query-key';
 import queryClient from '@libs/query-client';
 import { mutationOptions } from '@tanstack/react-query';
 import type { responseTypes } from '@/shared/types/base-types';
-import type {
-  postAgreementInfoRequest,
-  postUserInfoNicknameRequest,
-  postUserInfoRequest,
-} from '@/shared/types/user-types';
+import type { postAgreementInfoRequest, postUserInfoRequest } from '@/shared/types/user-types';
 
 export const userMutations = {
-  NICKNAME: () =>
-    mutationOptions<responseTypes, Error, postUserInfoNicknameRequest>({
-      mutationKey: USER_KEY.NICKNAME(),
-      mutationFn: ({ nickname }) => post(END_POINT.POST_INFO_NICKNAME, { nickname }),
-    }),
-
   USER_INFO: () =>
     mutationOptions<responseTypes, Error, postUserInfoRequest>({
       mutationKey: USER_KEY.INFO(),
-      mutationFn: ({ gender, birthYear }) => post(END_POINT.USER_INFO, { gender, birthYear }),
+      mutationFn: ({ nickname, introduction, birthYear, gender }) =>
+        post(END_POINT.USER_INFO, { nickname, introduction, birthYear, gender }),
     }),
 
   LOGOUT: () =>

--- a/src/shared/apis/user/user-mutations.ts
+++ b/src/shared/apis/user/user-mutations.ts
@@ -4,7 +4,11 @@ import { USER_KEY } from '@constants/query-key';
 import queryClient from '@libs/query-client';
 import { mutationOptions } from '@tanstack/react-query';
 import type { responseTypes } from '@/shared/types/base-types';
-import type { postUserInfoNicknameRequest, postUserInfoRequest } from '@/shared/types/user-types';
+import type {
+  postAgreementInfoRequest,
+  postUserInfoNicknameRequest,
+  postUserInfoRequest,
+} from '@/shared/types/user-types';
 
 export const userMutations = {
   NICKNAME: () =>
@@ -31,5 +35,11 @@ export const userMutations = {
       onError: (err) => {
         console.error('로그아웃 실패', err);
       },
+    }),
+
+  AGREEEMENT_INFO: () =>
+    mutationOptions<responseTypes, Error, postAgreementInfoRequest>({
+      mutationKey: USER_KEY.AGREEMENT(),
+      mutationFn: ({ hasAccepted }) => post(END_POINT.AGREEMENT_INFO, { hasAccepted }),
     }),
 };

--- a/src/shared/components/button/button/styles/button-variants.ts
+++ b/src/shared/components/button/button/styles/button-variants.ts
@@ -11,6 +11,7 @@ export const buttonVariants = cva(
         white: 'bg-white text-gray-700',
         skyblueBorder: 'bg-main-200 text-main-900 outline outline-main-900',
         gray2: 'bg-background text-gray-700',
+        disabled: 'bg-gray-100 text-gray-400',
       },
       size: {
         M: 'w-full px-[0.8rem] py-[1.2rem]',

--- a/src/shared/components/card/match-card/styles/card-variants.ts
+++ b/src/shared/components/card/match-card/styles/card-variants.ts
@@ -9,7 +9,7 @@ export const cardVariants = cva('relative w-full rounded-[12px] bg-white', {
       user: 'p-[2rem] shadow-1',
     },
     color: {
-      active: 'bg-main-200 outline outline-[1px] outline-main-600',
+      active: 'bg-main-200 outline outline-main-600',
       inactive: 'bg-white',
     },
   },

--- a/src/shared/components/divider/divider.tsx
+++ b/src/shared/components/divider/divider.tsx
@@ -1,0 +1,32 @@
+import clsx from 'clsx';
+
+interface DividerProps {
+  direction?: 'horizontal' | 'vertical';
+  color?: string; // tailwind 클래스 ex: bg-gray-200
+  thickness?: number; // rem 단위 숫자 ex: 0.1 -> 0.1rem
+  margin?: string; // tailwind 마진 클래스
+  className?: string;
+}
+
+const Divider = ({
+  direction = 'horizontal',
+  color = 'bg-gray-200',
+  thickness = 0.1,
+  margin,
+  className,
+}: DividerProps) => {
+  const isHorizontal = direction === 'horizontal';
+
+  return (
+    <div
+      className={clsx(
+        isHorizontal ? `w-full ${margin || 'my-4'}` : `h-full ${margin || 'mx-4'}`,
+        color,
+        className,
+      )}
+      style={isHorizontal ? { height: `${thickness}rem` } : { width: `${thickness}rem` }}
+    />
+  );
+};
+
+export default Divider;

--- a/src/shared/components/footer/constants/legal.ts
+++ b/src/shared/components/footer/constants/legal.ts
@@ -1,6 +1,1 @@
-export const MATCHING_PLATFORM_NOTICE = `※ 메잇볼은 고객 간의 야구 직관 메이트 매칭을 중개하는 플랫폼으로,
-직접적인 만남이나 거래에 개입하지 않으며, 이에 대한 책임을 지지
-않습니다.
-이용자 간 약속 및 행동에 대한 주의가 필요합니다.`;
-
 export const COPYRIGHT_NOTICE = '© 2025 MateBall. All rights reserved.';

--- a/src/shared/components/footer/footer.tsx
+++ b/src/shared/components/footer/footer.tsx
@@ -1,4 +1,4 @@
-import { COPYRIGHT_NOTICE, MATCHING_PLATFORM_NOTICE } from '@components/footer/constants/legal';
+import { COPYRIGHT_NOTICE } from '@components/footer/constants/legal';
 import Icon from '@components/icon/icon';
 import { EXTERNAL_LINKS } from '@constants/links';
 import { ROUTES } from '@routes/routes-config';
@@ -12,7 +12,7 @@ const Footer = () => {
 
   return (
     <footer
-      className={clsx('cap_12_m w-full flex-col gap-[4.8rem] px-[1.6rem] py-[3.2rem]', {
+      className={clsx('cap_12_m w-full flex-col gap-[2.4rem] px-[1.6rem] py-[3.2rem]', {
         'bg-gray-200': isHome,
       })}
     >
@@ -24,7 +24,6 @@ const Footer = () => {
         </div>
       </div>
       <div className="flex-col gap-[0.8rem] text-gray-600">
-        <p className="whitespace-pre-line">{MATCHING_PLATFORM_NOTICE}</p>
         <div className="flex-row gap-[0.8rem] py-[0.4rem]">
           <a
             href={EXTERNAL_LINKS.PRIVACY_POLICY}

--- a/src/shared/components/header/header.tsx
+++ b/src/shared/components/header/header.tsx
@@ -11,14 +11,15 @@ const Header = () => {
   const isFail = urlParams.get('type') === 'fail';
   const isSignUp = pathname.includes(ROUTES.SIGNUP);
   const isHome = pathname === ROUTES.HOME;
-  const isMatch = location.pathname === ROUTES.MATCH;
+  const isMatch = pathname === ROUTES.MATCH;
   const isChatRoom = pathname === ROUTES.CHAT_ROOM;
+  const isEditProfile = pathname === ROUTES.PROFILE_EDIT;
 
   return (
     <header
       className={clsx('header-layout', {
         'bg-gray-black': isFail || isHome,
-        'bg-gray-white': isSignUp || isChatRoom,
+        'bg-gray-white': isSignUp || isChatRoom || isEditProfile,
         'bg-gray-100': isMatch,
       })}
     >

--- a/src/shared/components/header/utils/get-header.tsx
+++ b/src/shared/components/header/utils/get-header.tsx
@@ -60,7 +60,7 @@ export const getHeaderContent = (
   }
 
   if (pathname === ROUTES.PROFILE) {
-    return <h1 className="head_20_sb text-gray-black">내 정보</h1>;
+    return <h1 className="head_20_sb text-gray-black">마이페이지</h1>;
   }
 
   if (pathname === ROUTES.CHAT) {

--- a/src/shared/constants/api.ts
+++ b/src/shared/constants/api.ts
@@ -10,6 +10,7 @@ export const END_POINT = {
 
   // 유저 관련
   GET_KAKAO_INFO: '/v1/users/kakao/info',
+  AGREEMENT_INFO: '/v2/users/consent',
   USER_INFO: '/v1/users/info',
   POST_INFO_NICKNAME: '/v1/users/info/nickname',
 

--- a/src/shared/constants/api.ts
+++ b/src/shared/constants/api.ts
@@ -11,8 +11,7 @@ export const END_POINT = {
   // 유저 관련
   GET_KAKAO_INFO: '/v1/users/kakao/info',
   AGREEMENT_INFO: '/v2/users/consent',
-  USER_INFO: '/v1/users/info',
-  POST_INFO_NICKNAME: '/v1/users/info/nickname',
+  USER_INFO: '/v2/users/info',
 
   // 경기 관련
   GET_GAME_SCHEDULE: (date: string) => `/v1/users/game/schedule?date=${date}`,

--- a/src/shared/constants/api.ts
+++ b/src/shared/constants/api.ts
@@ -5,6 +5,9 @@ export const END_POINT = {
   POST_AUTH_LOGIN: '/auth/login?code=',
   GET_USER_STATUS: '/v1/users/info-check',
 
+  // 로그아웃
+  POST_AUTH_LOGOUT: '/auth/logout',
+
   // 유저 관련
   GET_KAKAO_INFO: '/v1/users/kakao/info',
   USER_INFO: '/v1/users/info',

--- a/src/shared/constants/query-key.ts
+++ b/src/shared/constants/query-key.ts
@@ -3,6 +3,7 @@ export const USER_KEY = {
   ALL: ['user'] as const,
 
   KAKAO: () => [...USER_KEY.ALL, 'kakao'] as const,
+  AGREEMENT: () => [USER_KEY.ALL, 'agreement'] as const,
   INFO: () => [...USER_KEY.ALL, 'info'] as const,
   NICKNAME: () => [...USER_KEY.ALL, 'nickname'] as const,
   LOGOUT: () => [...USER_KEY.ALL, 'logout'] as const,

--- a/src/shared/constants/query-key.ts
+++ b/src/shared/constants/query-key.ts
@@ -5,6 +5,7 @@ export const USER_KEY = {
   KAKAO: () => [...USER_KEY.ALL, 'kakao'] as const,
   INFO: () => [...USER_KEY.ALL, 'info'] as const,
   NICKNAME: () => [...USER_KEY.ALL, 'nickname'] as const,
+  LOGOUT: () => [...USER_KEY.ALL, 'logout'] as const,
 } as const;
 
 export const AUTH_KEY = {

--- a/src/shared/constants/query-key.ts
+++ b/src/shared/constants/query-key.ts
@@ -3,7 +3,7 @@ export const USER_KEY = {
   ALL: ['user'] as const,
 
   KAKAO: () => [...USER_KEY.ALL, 'kakao'] as const,
-  AGREEMENT: () => [USER_KEY.ALL, 'agreement'] as const,
+  AGREEMENT: () => [...USER_KEY.ALL, 'agreement'] as const,
   INFO: () => [...USER_KEY.ALL, 'info'] as const,
   NICKNAME: () => [...USER_KEY.ALL, 'nickname'] as const,
   LOGOUT: () => [...USER_KEY.ALL, 'logout'] as const,

--- a/src/shared/routes/lazy.ts
+++ b/src/shared/routes/lazy.ts
@@ -19,7 +19,7 @@ export const Result = lazy(() => import('@pages/result/result'));
 
 // Mypage
 export const Profile = lazy(() => import('@pages/profile/profile'));
-export const EditProfile = lazy(() => import('@pages/profile/edit-profile/edit-profile'));
+export const EditProfile = lazy(() => import('@pages/edit-profile/edit-profile'));
 
 // Chat
 export const ChatList = lazy(() => import('@pages/chat/chat-list'));

--- a/src/shared/types/user-types.ts
+++ b/src/shared/types/user-types.ts
@@ -14,26 +14,19 @@ export interface getUserInfoResponse {
 }
 
 /**
- * 유저 정보 등록 요청
+ * 사용자 정보 설정
  * post
- * /v1/users/info
+ * /v2/users/info
  */
 export interface postUserInfoRequest {
-  gender: string;
-  birthYear: number;
-}
-
-/**
- * 유저 닉네임 등록 요청
- * post
- * /v1/users/info/nickname
- */
-export interface postUserInfoNicknameRequest {
   nickname: string;
+  introduction: string;
+  birthYear: number;
+  gender: string;
 }
 
 /**
- * 유저 약관동의
+ * 사용자 약관동의
  * post
  * /v2/users/consent
  */

--- a/src/shared/types/user-types.ts
+++ b/src/shared/types/user-types.ts
@@ -31,3 +31,12 @@ export interface postUserInfoRequest {
 export interface postUserInfoNicknameRequest {
   nickname: string;
 }
+
+/**
+ * 유저 약관동의
+ * post
+ * /v2/users/consent
+ */
+export interface postAgreementInfoRequest {
+  hasAccepted: boolean;
+}


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #323 

## ☀️ New-insight
- 이전 mutate가 성공한 후, 그 다음 mutate를 전송하기 위해 mutateSync를 사용한다!

## 💎 PR Point
- 약관 동의, 개인정보 제공 동의 > svg 클릭시 해당 notion으로 이동하게 연결했습니다
- 기존 nickname/user로 나뉘어있던 api를 sp1에 해당하는 user_info api 하나로 수정했습니다.
- 이용약관 동의 api 추가했습니다.

```ts
const onSubmit = async (data: UserInfoFormValues) => {
  const userData: postUserInfoRequest = {
    nickname: data.nickname,
    introduction: data.introduction,
    birthYear: Number(data.birthYear),
    gender: data.gender,
  };

  try {
    await agreementInfoMutaion.mutateAsync({ hasAccepted: true });
    await userInfoMutation.mutateAsync(userData);
  } catch (e) {
    console.error('signup failed:', e);
  }
};
```

- 사용자가 입력한 nickname, introduction등의 정보를 서버에서 요구하는 postUserInfoRequest 형태로 변환합니다.
- 약관 동의 정보는 `agreementInfoMutation.mutateAsync({ hasAccepted: true })` 호출을 통해
사용자가 서비스 약관에 동의했음을 서버에 먼저 기록합니다.
- 약관 동의가 성공하면 이어서 `userInfoMutation.mutateAsync(userData)`를 호출합니다.
- 두 요청 중 하나라도 실패하면 catch 블록에서 에러를 콘솔에 출력합니다. 실패시 가입 프로세스가 중단되며, 이후 후속 로직은 실행되지 않습니다.
- mutateAsync를 이용해 순차 실행을 보장하는 구조로 작성했습니다.



## 📸 Screenshot

테스트는 서버에서 제 유저 정보 DB 날려주면 해보고 추가할게용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 회원가입에 동의 단계와 약관/개인정보 링크가 추가되었고 새 탭으로 열립니다.
  - 편집 페이지(프로필 수정)와 선택 그룹 UI가 추가되었습니다.
  - 로그아웃 기능 및 프로필 화면에서 문의/의견 외부 링크가 추가되었습니다.
  - 공통 Divider 컴포넌트가 도입되었습니다.

- **개선 사항**
  - 가입 폼이 자기소개(introduction)를 포함한 단일 제출로 통합되어 흐름이 간소화되었습니다.
  - 버튼에 disabled 스타일 변형이 추가되었습니다.

- **기타**
  - 푸터의 매칭 플랫폼 고지 문구가 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->