### PR TITLE
feat: SP1 캘린더 로직 수정

### DIFF
--- a/src/pages/onboarding/components/date-select.tsx
+++ b/src/pages/onboarding/components/date-select.tsx
@@ -48,6 +48,7 @@ const DateSelect = () => {
           onWeekChange={handleDateSelect}
           onMonthChange={handleMonthChange}
           toastBottomOffset="2.4rem"
+          hasGame={() => (data?.length ?? 0) > 0}
         />
       </div>
 

--- a/src/pages/onboarding/constants/onboarding.ts
+++ b/src/pages/onboarding/constants/onboarding.ts
@@ -30,17 +30,17 @@ export const SYNC_MATE = ['같은 팀 메이트와 보고 싶어요', '상관없
 export const VIEWING_STYLE = [
   {
     id: 1,
-    label: '열정응원러',
+    label: '열정 응원러',
     icon: 'passion',
   },
   {
     id: 2,
-    label: '경기집중러',
+    label: '경기 집중러',
     icon: 'focus',
   },
   {
     id: 3,
-    label: '직관먹방러',
+    label: '직관 먹방러',
     icon: 'eat',
   },
 ];

--- a/src/shared/components/calendar/month-calendar.tsx
+++ b/src/shared/components/calendar/month-calendar.tsx
@@ -2,7 +2,7 @@ import { WEEK_DAY_COLORS, WEEK_DAYS } from '@components/calendar/constants/CALEN
 import { calendarDayVariants } from '@components/calendar/styles/calendar-day-variants';
 import { getMonthGrid } from '@components/calendar/utils/date-grid';
 import Icon from '@components/icon/icon';
-import { DATE_SELECT_TOAST_MESSAGE } from '@constants/error-toast';
+import { DATE_SELECT_TOAST_MESSAGE, NO_GAME_TOAST_MESSAGE } from '@constants/error-toast';
 import {
   addDays,
   addMonths,
@@ -23,6 +23,7 @@ interface MonthCalendarProps {
   onWeekChange: (date: Date) => void;
   onMonthChange: (date: Date) => void;
   toastBottomOffset?: '7.6rem' | '8.3rem' | '2.4rem';
+  hasGame?: (date: Date) => boolean;
 }
 
 const MonthCalendar = ({
@@ -32,6 +33,7 @@ const MonthCalendar = ({
   onWeekChange,
   onMonthChange,
   toastBottomOffset,
+  hasGame,
 }: MonthCalendarProps) => {
   const days = getMonthGrid(value);
   const startDate = startOfMonth(value);
@@ -77,6 +79,11 @@ const MonthCalendar = ({
               const isBlocked = day <= addDays(entryDate, 1);
               if (isBlocked) {
                 showErrorToast(DATE_SELECT_TOAST_MESSAGE, toastBottomOffset ?? '2.4rem');
+                return;
+              }
+
+              if (hasGame && !hasGame(day)) {
+                showErrorToast(NO_GAME_TOAST_MESSAGE, toastBottomOffset ?? '3.2rem');
                 return;
               }
               onWeekChange(day);

--- a/src/shared/components/calendar/month-calendar.tsx
+++ b/src/shared/components/calendar/month-calendar.tsx
@@ -1,4 +1,4 @@
-import { WEEK_DAY_COLORS, WEEK_DAYS, WEEKDAY } from '@components/calendar/constants/CALENDAR';
+import { WEEK_DAY_COLORS, WEEK_DAYS } from '@components/calendar/constants/CALENDAR';
 import { calendarDayVariants } from '@components/calendar/styles/calendar-day-variants';
 import { getMonthGrid } from '@components/calendar/utils/date-grid';
 import Icon from '@components/icon/icon';
@@ -70,8 +70,7 @@ const MonthCalendar = ({
           {days.map((day) => {
             const isSelected = selectedDate ? isSameDay(day, selectedDate) : false;
             const isPast = isBefore(startOfDay(day), startOfDay(new Date()));
-            const isMonday = day.getDay() === WEEKDAY.MONDAY;
-            const isDisabled = isPast || isMonday;
+            const isDisabled = isPast;
             const isNotCurrentMonth = day < startDate || day > endDate;
 
             const handleClick = (day: Date) => {

--- a/src/shared/components/calendar/styles/calendar-day-variants.ts
+++ b/src/shared/components/calendar/styles/calendar-day-variants.ts
@@ -12,9 +12,6 @@ export const calendarDayVariants = cva('flex-row-center text-center', {
       true: 'cursor-not-allowed text-gray-500',
       false: 'cursor-pointer text-gray-900',
     },
-    isMonday: {
-      true: 'text-gray-600',
-    },
     notCurrentMonth: {
       true: 'pointer-events-none opacity-0',
     },
@@ -26,6 +23,5 @@ export const calendarDayVariants = cva('flex-row-center text-center', {
   defaultVariants: {
     monthSelected: false,
     disabled: false,
-    isMonday: false,
   },
 });

--- a/src/shared/components/calendar/utils/date-grid.ts
+++ b/src/shared/components/calendar/utils/date-grid.ts
@@ -1,5 +1,4 @@
-import { WEEKDAY } from '@components/calendar/constants/CALENDAR';
-import { addDays, endOfMonth, getDay, isAfter, startOfMonth, startOfWeek } from 'date-fns';
+import { addDays, endOfMonth, isAfter, startOfMonth, startOfWeek } from 'date-fns';
 
 export const getWeekDays = (baseDate: Date): Date[] => {
   return Array.from({ length: 7 }, (_, i) => addDays(baseDate, i));
@@ -17,6 +16,5 @@ export const getMonthGrid = (date: Date): Date[] => {
 };
 
 export const getInitialSelectedDate = (entryDate: Date): Date => {
-  const base = addDays(entryDate, 2);
-  return getDay(base) === WEEKDAY.MONDAY ? addDays(base, 1) : base;
+  return addDays(entryDate, 2);
 };

--- a/src/shared/components/calendar/week-calendar.tsx
+++ b/src/shared/components/calendar/week-calendar.tsx
@@ -1,4 +1,3 @@
-import { WEEKDAY } from '@components/calendar/constants/CALENDAR';
 import { getWeekDays } from '@components/calendar/utils/date-grid';
 import { DATE_SELECT_TOAST_MESSAGE } from '@constants/error-toast';
 import { cn } from '@libs/cn';
@@ -21,14 +20,9 @@ const WeekCalendar = ({ entryDate, baseDate, value, onChange }: WeekCalendarProp
     <div className="w-full flex-row-between gap-[1.2rem]">
       {days.map((day) => {
         const isSelected = isSameDay(day, value);
-        const isMonday = day.getDay() === WEEKDAY.MONDAY;
 
-        const dateColor = isMonday ? 'text-gray-600' : 'text-gray-white';
-        const dayColor = isSelected
-          ? 'text-main-400'
-          : isMonday
-            ? 'text-gray-600'
-            : 'text-gray-500';
+        const dateColor = 'text-gray-white';
+        const dayColor = isSelected ? 'text-main-400' : 'text-gray-500';
 
         const handleClick = (day: Date) => {
           const isBlocked = day <= addDays(entryDate, 1);
@@ -45,11 +39,8 @@ const WeekCalendar = ({ entryDate, baseDate, value, onChange }: WeekCalendarProp
             key={day.toISOString()}
             type="button"
             onClick={() => handleClick(day)}
-            disabled={isMonday}
             className={calendarDayVariants({
               weekSelected: isSelected,
-              disabled: isMonday,
-              isMonday,
               size: 'week',
             })}
           >

--- a/src/shared/constants/error-toast.ts
+++ b/src/shared/constants/error-toast.ts
@@ -18,3 +18,5 @@ export const MATCH_PENDING_TOAST_MESSAGES = {
 };
 
 export const DATE_SELECT_TOAST_MESSAGE = '직관 준비를 위해 2일 후 날짜부터 선택 가능해요.';
+
+export const NO_GAME_TOAST_MESSAGE = '해당 날짜에는 진행되는 경기가 없어요';


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #311 

## ☀️ New-insight

- 월요일에도 선택 가능하도록 활성화 했습니다.
- 월요일이 활성화됨에 따라 토요일에 진입해도 월요일이 디폴트로 선택되게 수정했습니다.
- 홈화면에 있는 캘린더에서 월요일을 선택하면 엠티뷰가 보이고, 온보딩에 있는 캘린더에서 월요일을 선택하면 토스트가 뜰 수 있게 수정했습니다.

## 💎 PR Point

자세한 설명은 코드에 달아놓을게요 !!

## 📸 Screenshot

서버에서 온보딩 정보 지워주시면 테스트해서 영상 올릴게요 !