### PR TITLE
fix: SP1 라벨 수정 

### DIFF
--- a/src/pages/edit-profile/constants/edit-profile.ts
+++ b/src/pages/edit-profile/constants/edit-profile.ts
@@ -3,14 +3,14 @@ export const PROFILE_SYNC_MATE = ['같은 팀 메이트', '상관없어요'];
 export const PROFILE_VIEWING_STYLE = [
   {
     id: 1,
-    label: '열정 응원러',
+    label: '열정응원러',
   },
   {
     id: 2,
-    label: '경기 집중러',
+    label: '경기집중러',
   },
   {
     id: 3,
-    label: '직관 먹방러',
+    label: '직관먹방러',
   },
 ];

--- a/src/pages/onboarding/constants/onboarding.ts
+++ b/src/pages/onboarding/constants/onboarding.ts
@@ -30,17 +30,17 @@ export const SYNC_MATE = ['같은 팀 메이트와 보고 싶어요', '상관없
 export const VIEWING_STYLE = [
   {
     id: 1,
-    label: '열정 응원러',
+    label: '열정응원러',
     icon: 'passion',
   },
   {
     id: 2,
-    label: '경기 집중러',
+    label: '경기집중러',
     icon: 'focus',
   },
   {
     id: 3,
-    label: '직관 먹방러',
+    label: '직관먹방러',
     icon: 'eat',
   },
 ];


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #337 

## 💎 PR Point

서버에서 받아오는 라벨 값에서 공백이 모두 삭제되어 그 부분 반영했습니다.

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 프로필 편집 및 온보딩 화면의 관람 스타일 라벨 표기를 일관되게 정리했습니다.
    - ‘열정 응원러’ → ‘열정응원러’
    - ‘경기 집중러’ → ‘경기집중러’
    - ‘직관 먹방러’ → ‘직관먹방러’
  - 라벨 가독성과 UI 일관성을 개선했으며, 아이콘이나 항목 구성에는 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->