### PR TITLE
fix: (QA/3) 응원하는 팀이 없는 경우 분기처리

### DIFF
--- a/src/pages/onboarding/onboarding.tsx
+++ b/src/pages/onboarding/onboarding.tsx
@@ -10,7 +10,7 @@ import Start from '@pages/onboarding/components/start';
 import SupportTeam from '@pages/onboarding/components/support-team';
 import SyncSupportTeam from '@pages/onboarding/components/sync-support-team';
 import ViewingStyle from '@pages/onboarding/components/viewing-style';
-import { FIRST_FUNNEL_STEPS } from '@pages/onboarding/constants/onboarding';
+import { FIRST_FUNNEL_STEPS, NO_TEAM_OPTION } from '@pages/onboarding/constants/onboarding';
 import {
   getButtonLabel,
   handleButtonClick,
@@ -22,7 +22,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 const Onboarding = () => {
-  const { Funnel, Step, currentStep, currentIndex, steps, goNext, goPrev } = useFunnel(
+  const { Funnel, Step, currentStep, currentIndex, steps, goNext, goPrev, goTo } = useFunnel(
     FIRST_FUNNEL_STEPS,
     ROUTES.HOME,
   );
@@ -111,7 +111,12 @@ const Onboarding = () => {
             size="L"
             variant="blue"
             disabled={isButtonDisabled(currentStep, selections)}
-            onClick={() =>
+            onClick={() => {
+              if (currentStep === 'SUPPORT_TEAM' && selections.SUPPORT_TEAM === NO_TEAM_OPTION) {
+                goTo('VIEWING_STYLE');
+                return;
+              }
+
               handleButtonClick(
                 currentStep,
                 selections,
@@ -119,8 +124,8 @@ const Onboarding = () => {
                 navigate,
                 setProgressOverride,
                 mutate,
-              )
-            }
+              );
+            }}
           />
         </div>
       </div>

--- a/src/pages/onboarding/onboarding.tsx
+++ b/src/pages/onboarding/onboarding.tsx
@@ -113,6 +113,7 @@ const Onboarding = () => {
             disabled={isButtonDisabled(currentStep, selections)}
             onClick={() => {
               if (currentStep === 'SUPPORT_TEAM' && selections.SUPPORT_TEAM === NO_TEAM_OPTION) {
+                setSelections((prev) => ({ ...prev, SYNC_SUPPORT_TEAM: null }));
                 goTo('VIEWING_STYLE');
                 return;
               }


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #345 

## ☀️ New-insight

- NO_TEAM_OPTION 상수를 문자열 그대로 비교("NO_TEAM_OPTION")하면 조건이 먹히지 않고, 실제 상수 값("응원하는 팀이 없어요.")과 비교해야 정확히 동작한다..
- 공통 유틸(handleButtonClick)에서 처리하기보다는 Onboarding 컴포넌트 내부에서만 goTo를 사용해 분기 처리하면 타입 충돌 없이 안전하게 제어할 수 있다.

## 💎 PR Point

- 온보딩 플로우에서 NO_TEAM_OPTION 선택 시 SYNC_SUPPORT_TEAM 단계를 건너뛰고 바로 VIEWING_STYLE 단계로 이동하도록 로직을 추가했습니다.

- Onboarding 컴포넌트 내부 버튼 핸들러에서 currentStep과 selections.SUPPORT_TEAM을 체크하여 goTo('VIEWING_STYLE')로 분기 처리했습니다.

## 📸 Screenshot

https://github.com/user-attachments/assets/6098cc46-caf8-45a3-8953-09a1b011a72f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 온보딩 플로우 업데이트: 지원 팀 단계에서 ‘팀 없음’ 선택 시 즉시 ‘시청 스타일’ 단계로 건너뛰어 불필요한 단계와 클릭을 제거합니다.
  * 온보딩 단계 이동 제어 추가로 특정 선택에 대해 즉시 다음 단계로 전환되며, 다른 선택지는 기존 진행 흐름을 유지합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->