### PR TITLE
fix: (QA/3) 그룹장 온보딩 완료 화면 분기처리

### DIFF
--- a/src/pages/onboarding/components/date-select.tsx
+++ b/src/pages/onboarding/components/date-select.tsx
@@ -11,7 +11,11 @@ import { format } from 'date-fns';
 import { useState } from 'react';
 import { showErrorToast } from '@/shared/utils/show-error-toast';
 
-const DateSelect = () => {
+interface DateSelectProps {
+  groupRole: string | null;
+}
+
+const DateSelect = ({ groupRole }: DateSelectProps) => {
   const initialSelectedDate = getInitialSelectedDate(new Date());
   const [selectedDate, setSelectedDate] = useState<Date | null>(initialSelectedDate);
   const [currentMonth, setCurrentMonth] = useState<Date>(initialSelectedDate);
@@ -71,6 +75,7 @@ const DateSelect = () => {
         gameSchedule={data ?? []}
         activeType={activeType}
         fromOnboarding={true}
+        groupRole={groupRole}
       />
     </div>
   );

--- a/src/pages/onboarding/onboarding-group.tsx
+++ b/src/pages/onboarding/onboarding-group.tsx
@@ -52,7 +52,7 @@ const OnboardingGroup = () => {
           </Step>
 
           <Step name="DATE_SELECT">
-            <DateSelect />
+            <DateSelect groupRole={selection.GROUP_ROLE} />
           </Step>
 
           <Step name="COMPLETE">

--- a/src/shared/components/bottom-sheet/game-match/game-match-bottom-sheet.tsx
+++ b/src/shared/components/bottom-sheet/game-match/game-match-bottom-sheet.tsx
@@ -29,6 +29,7 @@ interface GameMatchBottomSheetProps {
   onClick?: (selectedId: number | null) => void;
   activeType: TabType;
   fromOnboarding?: boolean;
+  groupRole?: string | null;
 }
 
 const GameMatchBottomSheet = ({
@@ -38,6 +39,7 @@ const GameMatchBottomSheet = ({
   gameSchedule,
   activeType,
   fromOnboarding = false,
+  groupRole,
 }: GameMatchBottomSheetProps) => {
   const [selectedIdx, setSelectedIdx] = useState<number | null>(null);
   const navigate = useNavigate();
@@ -80,7 +82,11 @@ const GameMatchBottomSheet = ({
           handleClose();
 
           if (fromOnboarding) {
-            navigate(`${ROUTES.ONBOARDING_GROUP}?step=COMPLETE`);
+            if (groupRole === '그룹장') {
+              navigate(`${ROUTES.MATCH_CREATE(createdMatchId)}?type=${queryType}`);
+            } else {
+              navigate(`${ROUTES.ONBOARDING_GROUP}?step=COMPLETE`);
+            }
           } else {
             navigate(`${ROUTES.MATCH_CREATE(createdMatchId)}?type=${queryType}`);
           }


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #348 

## ☀️ New-insight

온보딩을 마쳤을 때 그룹원은 COMPLETE 단계로, 그룹장은 MATCH_CREATE 페이지로 이동해야 하는 플로우였다... 화면설계서를 꼼꼼히 읽을 것......😅

## 💎 PR Point

**OnboardingGroup**
- `selection.GROUP_ROLE` 상태를 관리하고 `DateSelect`로 전달하도록 수정.

**DateSelect**
- groupRole props를 받아 `GameMatchBottomSheet`까지 전달.

**GameMatchBottomSheet**
- groupRole props 추가 및 분기 처리:
    - 그룹장(그룹장) → 매치 생성 성공 시 `ROUTES.MATCH_CREATE`로 이동.
    - 그룹원(그룹원) → 매치 생성 성공 시 `COMPLETE` 스텝으로 이동.

## 📸 Screenshot

https://github.com/user-attachments/assets/d6067693-6862-4413-a508-37fc5e418b7f


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새로운 기능
  - 온보딩의 날짜 선택 단계가 사용자가 선택한 그룹 역할에 맞게 표시와 안내가 조정됩니다.
  - 온보딩 완료 시, 그룹장으로 가입한 경우 즉시 매치 생성 화면으로 이동합니다. 다른 역할은 기존 완료 흐름을 유지합니다.
  - 일반(온보딩 외) 매치 생성 흐름은 동일하며, 역할에 맞는 경로로 자연스럽게 이어집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->