### PR TITLE
fix: (QA/3) bottom navigation 네이밍 수정

### DIFF
--- a/src/shared/components/bottom-navigation/bottom-navigation.tsx
+++ b/src/shared/components/bottom-navigation/bottom-navigation.tsx
@@ -34,7 +34,7 @@ const BottomNavigation = () => {
             key={label}
             type="button"
             className={cn(
-              'h-[4.8rem] w-[4.8rem] flex-col-center gap-[0.4rem]',
+              'h-[4.8rem] w-[5.6rem] flex-col-center gap-[0.4rem]',
               disabled ? 'cursor-not-allowed' : 'cursor-pointer',
             )}
             onClick={() => handleTabClick(path)}

--- a/src/shared/components/bottom-navigation/constants/bottom-navigation.ts
+++ b/src/shared/components/bottom-navigation/constants/bottom-navigation.ts
@@ -26,7 +26,7 @@ export const NAV_ITEMS = [
     },
   },
   {
-    label: '내 정보',
+    label: '마이페이지',
     path: ROUTES.PROFILE,
     icon: {
       filled: 'my-filled',


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #350 

## ☀️ New-insight

- 태스크 까먹음 이슈 ㅎㅎ;

## 💎 PR Point

- '내 정보' -> '마이페이지' 네이밍 수정
- 버튼 width 조정

## 📸 Screenshot
<img width="454" height="88" alt="스크린샷 2025-09-06 오후 7 38 11" src="https://github.com/user-attachments/assets/6c753890-e12c-4bd9-abdb-132356cfa10f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 하단 내비게이션 버튼의 가로 크기를 4.8rem에서 5.6rem으로 확대하여 버튼 레이아웃과 시각적 균형을 조정했습니다. 높이(4.8rem)와 기타 동작(활성/비활성, 아이콘, 배지, 클릭 처리)은 그대로 유지됩니다.
  - 하단 내비게이션의 프로필 메뉴 레이블을 ‘내 정보’에서 ‘마이페이지’로 변경하여 표시 텍스트를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->