### PR TITLE
fix: (QA/3) 이용가이드 디자인 반영

### DIFF
--- a/src/shared/components/card/banner-card/banner-card.tsx
+++ b/src/shared/components/card/banner-card/banner-card.tsx
@@ -11,7 +11,7 @@ const BannerCard = ({ text, subText, className }: CardBannerProps) => {
   return (
     <div className={cn('relative w-full', className)}>
       <img src={BannerImg} alt="홈배너" className="w-full" />
-      <div className="absolute inset-0 flex-col gap-[0.4rem] py-[2.2rem] pl-[2.4rem]">
+      <div className="absolute inset-0 flex-col justify-center gap-[0.4rem] py-[2.2rem] pl-[2.4rem]">
         <p className="cap_14_m text-gray-800">{subText}</p>
         <p className="subhead_18_sb text-gray-black">{text}</p>
       </div>

--- a/src/shared/components/card/banner-card/banner-card.tsx
+++ b/src/shared/components/card/banner-card/banner-card.tsx
@@ -11,7 +11,7 @@ const BannerCard = ({ text, subText, className }: CardBannerProps) => {
   return (
     <div className={cn('relative w-full', className)}>
       <img src={BannerImg} alt="홈배너" className="w-full" />
-      <div className="absolute inset-0 flex-col gap-[0.4rem] py-[2rem] pl-[2.4rem]">
+      <div className="absolute inset-0 flex-col gap-[0.4rem] py-[2.2rem] pl-[2.4rem]">
         <p className="cap_14_m text-gray-800">{subText}</p>
         <p className="subhead_18_sb text-gray-black">{text}</p>
       </div>


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #352 

## ☀️ New-insight

피그마와의 간격은 맞는데 반응형이 안 되어 있어서 qa 때 중앙정렬이 안 된 것 같아요~ 반응형 항상 체크해주세용

## 💎 PR Point

- padding 조정
- justify-content 속성 추가

## 📸 Screenshot
<img width="495" height="234" alt="스크린샷 2025-09-06 오후 9 03 10" src="https://github.com/user-attachments/assets/252bcbf4-2a2a-4323-a0f0-c1fe0e32d72c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 배너 카드 오버레이의 두 텍스트 블록을 세로 중앙 정렬로 조정하여 화면 전반의 균형과 가독성을 향상했습니다.
  - 세로 패딩을 소폭 증가시켜 여백을 정돈하고 시각적 안정감을 높였습니다.
  - 다양한 화면 크기에서 더 일관된 레이아웃을 제공해 콘텐츠 집중도를 개선했습니다.
  - 기능적 동작이나 상호작용 변화 없이 시각적 표현만 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->