### PR TITLE
fix: (QA/3) 매칭현황 탭 스타일 수정

### DIFF
--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -48,7 +48,7 @@ const Home = () => {
   };
 
   return (
-    <div className="bg-gray-200 pb-[5.6rem]">
+    <div className="h-full bg-gray-200 pb-[5.6rem]">
       <TopSection />
       <CalendarSection
         activeType={activeType}

--- a/src/pages/match/components/match-tab-pannel.tsx
+++ b/src/pages/match/components/match-tab-pannel.tsx
@@ -56,7 +56,7 @@ const MatchTabPanel = ({ cards, filter }: MatchTabPanelProps) => {
       {filteredCards.length === 0 ? (
         <EmptyView
           iconName="empty"
-          className="mt-[6.5rem]"
+          className="mt-[8.5rem]"
           text="아직 매칭된 메이트가 없어요!"
           subText="홈 화면에서 메이트를 먼저 찾아 보세요."
         />

--- a/src/pages/match/components/match-tab-pannel.tsx
+++ b/src/pages/match/components/match-tab-pannel.tsx
@@ -52,7 +52,7 @@ const MatchTabPanel = ({ cards, filter }: MatchTabPanelProps) => {
   };
 
   return (
-    <div className="flex-col gap-[0.8rem] px-[1.6rem] py-[2rem]">
+    <div className="flex-col gap-[0.8rem] px-[1.6rem]">
       {filteredCards.length === 0 ? (
         <EmptyView
           iconName="empty"

--- a/src/pages/match/match.tsx
+++ b/src/pages/match/match.tsx
@@ -40,7 +40,7 @@ const Match = () => {
           onTabChange={handleTabChange}
         />
         <FillTabList
-          className="px-[1.6rem] py-[1.2rem]"
+          className="my-[0.8rem] px-[1.6rem] py-[1.2rem]"
           tabs={fillTabItems}
           selected={filter}
           onChange={handleFilterChange}

--- a/src/shared/components/tab/fill-tab/fill-tab-item.tsx
+++ b/src/shared/components/tab/fill-tab/fill-tab-item.tsx
@@ -14,7 +14,7 @@ const FillTabItem = ({ title, isActive, onClick }: FillTabItemProps) => {
       onClick={onClick}
       className={cn(
         'flex-row-center rounded-[8px] px-[1.2rem] py-[0.6rem]',
-        isActive ? 'bg-main-900' : 'cursor-pointer bg-gray-300',
+        isActive ? 'bg-main-900' : 'cursor-pointer bg-gray-250',
       )}
     >
       <span

--- a/src/shared/components/tab/tab/styles/tab-style.ts
+++ b/src/shared/components/tab/tab/styles/tab-style.ts
@@ -10,7 +10,7 @@ export const tabStyleMap = {
     textStyle: 'subhead_18_sb',
   },
   match: {
-    gap: 'gap-[2.4rem] px-[1.6rem] border-b border-gray-300',
+    gap: 'px-[1.6rem] border-b border-gray-300',
     textActive: 'text-gray-black',
     textInactive: 'text-gray-600',
     borderActive: 'after:bg-gray-black',

--- a/src/shared/components/ui/empty-view.tsx
+++ b/src/shared/components/ui/empty-view.tsx
@@ -10,11 +10,11 @@ interface EmptyViewProps {
 
 const EmptyView = ({ iconName, text, subText, className }: EmptyViewProps) => {
   return (
-    <div className={cn('mt-[2.4rem] flex-col-center', className)}>
+    <div className={cn('flex-col-center gap-[2.4rem]', className)}>
       <Icon name={iconName} size={8.4} />
-      <div className="text-center">
-        <h3 className="head_20_sb mt-[2.4rem]">{text}</h3>
-        <p className="cap_14_m mt-[0.8rem] text-gray-500">{subText}</p>
+      <div className="flex-col-center gap-[0.8rem] text-center">
+        <h3 className="head_20_sb">{text}</h3>
+        <p className="cap_14_m text-gray-500">{subText}</p>
       </div>
     </div>
   );

--- a/src/shared/styles/theme.css
+++ b/src/shared/styles/theme.css
@@ -38,6 +38,7 @@
   --color-gray-500: #acadae;
   --color-gray-400: #cacbcd;
   --color-gray-300: #e4e4e6;
+  --color-gray-250: #ededed;
   --color-gray-200: #f1f1f3;
   --color-gray-100: #f6f7f9;
   --color-gray-white: #ffffff;


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #355 

## ☀️ New-insight

- 항상 피그마를 꼼꼼히 보시온.

## 💎 PR Point

- 1:1, 그룹 탭 바 사이 간격 조정
- 전체/대기중/완료/실패 탭 간격 조정
- 매칭 카드 간 간격 조정
- 색상 추가 및 버튼 색상 변경
- 추가로 qa에는 없었지만^^ 화면이 길어지면 메인 백그라운드가 보이는 현상이 있어 `h-full` 추가

## 📸 Screenshot
### 전 / 후
<img width="917" height="323" alt="스크린샷 2025-09-06 오후 11 10 44" src="https://github.com/user-attachments/assets/f5328ce8-7ad7-4b04-be34-be60f38dfe9c" />

여기저기 간격 조정, 색상 변경

<img width="918" height="421" alt="스크린샷 2025-09-06 오후 11 11 21" src="https://github.com/user-attachments/assets/d08d3ac8-ed64-4138-9163-703c05153b69" />

엠티뷰 간격 조정

<img width="917" height="947" alt="스크린샷 2025-09-06 오후 10 56 34" src="https://github.com/user-attachments/assets/049c340b-3855-4b74-80c2-f0749f6a570b" />

h-full 속성 추가
