### PR TITLE
fix: (QA/3) 왕관 아이콘 위치 조정 및 그림자 제거

### DIFF
--- a/src/shared/components/card/match-card/components/card-header.tsx
+++ b/src/shared/components/card/match-card/components/card-header.tsx
@@ -37,7 +37,7 @@ const CardHeader = (props: CardProps) => {
             className={cn(
               'pointer-events-none absolute z-[var(--z-card-owner)]',
               spec.pos,
-              'grid place-items-center rounded-full shadow-sm',
+              'grid place-items-center rounded-full',
               spec.box,
             )}
           >

--- a/src/shared/components/card/match-card/components/card-header.tsx
+++ b/src/shared/components/card/match-card/components/card-header.tsx
@@ -16,13 +16,13 @@ const CardHeader = (props: CardProps) => {
     if (t === 'group') {
       return {
         box: 'h-[1.2rem] w-[1.2rem]',
-        pos: 'left-[1.4rem] -bottom-[0.2rem]',
+        pos: 'left-[1.6rem] bottom-0',
         size: 1.2,
       };
     }
     return {
       box: 'h-[1.6rem] w-[1.6rem]',
-      pos: 'right-[0.3rem] -bottom-[0.2rem]',
+      pos: 'right-0 bottom-0',
       size: 1.6,
     };
   };


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #357 

## ☀️ New-insight

- 디자이너의 눈은 다르다...

## 💎 PR Point

- 위치 안 맞아서 조절했어요
- 그림자 제거했어요

## 📸 Screenshot
### 전 / 후
<img width="435" height="244" alt="스크린샷 2025-09-06 오후 11 29 24" src="https://github.com/user-attachments/assets/d95a5161-f463-47bb-be59-b66caa3f35e0" />
<img width="197" height="122" alt="스크린샷 2025-09-06 오후 11 30 06" src="https://github.com/user-attachments/assets/a3969237-faf6-47f7-a27c-87539a386f7c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 스타일
  * 매치 카드 헤더의 왕관 아이콘 위치와 시각 효과를 개선했습니다.
    - 그룹 타입: 아이콘을 약간 재배치하여 정렬을 더욱 자연스럽게 조정.
    - 기타 타입: 아이콘을 카드 우하단에 밀착 배치해 일관성 강화.
    - 아이콘 컨테이너의 드롭 섀도우를 제거해 더 깔끔하고 선명한 표시로 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->