### PR TITLE
fix: (QA/3) 그룹 매칭 수락 시 매칭 현황 화면으로 이동

### DIFF
--- a/src/pages/result/components/matching-receive-view.tsx
+++ b/src/pages/result/components/matching-receive-view.tsx
@@ -67,8 +67,11 @@ const MatchingReceiveView = ({ isGroupMatching = true }: MatchingReceiveViewProp
       onSuccess: () => {
         readAlarm(parsedId, {
           onSuccess: () => {
-            const resultType = cardType === 'group' ? 'agree' : 'success';
-            navigate(`${ROUTES.RESULT(matchId)}?type=${resultType}`);
+            if (cardType === 'group') {
+              navigate(`${ROUTES.MATCH}?tab=그룹&filter=전체`);
+            } else {
+              navigate(`${ROUTES.RESULT(matchId)}?type=success`);
+            }
           },
           onError: () => {
             navigate(ROUTES.ERROR);


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #359 

## ☀️ New-insight

- 화면설계서 꼼꼼히22......^^

## 💎 PR Point

- ‘수락하기’ 버튼 클릭시 매칭현황 페이지의 그룹 탭으로 이동시켰습니다

## 📸 Screenshot
녹화는 못했지만 되는 거 확인했어여!!...ㅎㅎ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 매칭 수락 후 알림을 성공적으로 확인했을 때의 이동 경로를 개선했습니다. 그룹 매칭은 매칭 화면의 ‘그룹’ 탭(필터: 전체)으로 이동하고, 개인/일반 매칭은 결과 화면의 성공 페이지로 이동합니다. 오류 발생 시 처리와 이후 데이터 새로고침 동작은 기존과 동일합니다. 이로써 사용자 혼란을 줄이고 일관된 화면 흐름을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->