### PR TITLE
fix: (QA/3) 그룹요청도착 서브텍스트 수정

### DIFF
--- a/src/pages/result/components/matching-receive-view.tsx
+++ b/src/pages/result/components/matching-receive-view.tsx
@@ -14,15 +14,12 @@ import { ROUTES } from '@routes/routes-config';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
-interface MatchingReceiveViewProps {
-  isGroupMatching?: boolean;
-}
-
-const MatchingReceiveView = ({ isGroupMatching = true }: MatchingReceiveViewProps) => {
+const MatchingReceiveView = () => {
   const { matchId } = useParams();
   const navigate = useNavigate();
   const [params] = useSearchParams();
   const cardType = params.get('cardtype');
+  const isGroupMatching = cardType === 'group';
 
   usePreventBackNavigation(
     `${ROUTES.MATCH}?tab=${cardType === 'group' ? '그룹' : '1:1'}&filter=전체`,

--- a/src/pages/result/result.tsx
+++ b/src/pages/result/result.tsx
@@ -36,7 +36,7 @@ const ResultPage = () => {
   }
 
   if (type === 'received') {
-    return <MatchingReceiveView isGroupMatching={isGroupMatching} />;
+    return <MatchingReceiveView />;
   }
 
   return <Navigate to={ROUTES.ERROR} replace />;


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #354 

## ☀️ New-insight

<!-- 새롭게 알게 된 부분을 적어주세요! (기록하면서 개발하기!) -->

## 💎 PR Point

- 다른 브랜치 작업들 다 머지되면 다시 테스트 해봐야 할 것 같긴해요...ㅎㅎ 일단 올려놓을게여!~

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 수신 결과 화면이 라우트의 쿼리 파라미터를 기준으로 그룹/개인 매칭 모드를 자동 인식하도록 내부 로직을 단순화했습니다.
  - 호출부에서 별도의 모드 전달이 필요 없도록 연결 방식을 정리해 화면 간 일관성을 높였습니다.
- Chores
  - 불필요한 전달값을 제거해 유지보수성을 개선했습니다.
- 기타
  - 사용자 입장에서는 기능 변화 없이 동일하게 동작하며, 설정 불일치로 인한 혼선을 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->