### PR TITLE
fix: (QA/3) 한줄소개 글자수 제한 로직 추가 

### DIFF
--- a/src/shared/components/input/input.tsx
+++ b/src/shared/components/input/input.tsx
@@ -62,6 +62,7 @@ const Input = ({
           <textarea
             id={id}
             ref={ref as React.Ref<HTMLTextAreaElement>}
+            maxLength={maxLength}
             className={cn(
               'w-full bg-transparent text-gray-black outline-none placeholder:text-gray-500',
               'resize-none whitespace-pre-wrap break-words',


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #362 

## 💎 PR Point
- input 컴포넌트의 textarea 속성에 maxLength 추가해서 최대 길이 이상으로 글씨 안써지게 수정했슨


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 새로운 기능
  * 멀티라인 텍스트 입력에 최대 글자수 제한을 추가했습니다. 컴포넌트의 maxLength 값이 HTML 속성에 반영되며 기본값은 50자입니다. 필요 시 prop으로 조정할 수 있습니다. 단일행 입력에는 영향이 없습니다. 이로써 과도한 입력을 사전에 방지하고 일관된 입력 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->