### PR TITLE
fix: (QA/3) 마이페이지, 프로필 수정 페이지 디자인 QA 반영

### DIFF
--- a/src/pages/edit-profile/edit-profile.tsx
+++ b/src/pages/edit-profile/edit-profile.tsx
@@ -150,20 +150,33 @@ const EditProfile = () => {
         <div className="mb-[2.5rem] flex justify-end gap-[0.8rem]">
           <Button
             type="button"
-            variant="skyblue"
+            variant={
+              !!errors.nickname || nicknameVal.trim().length === 0 || isSubmitting
+                ? 'disabled'
+                : 'skyblue'
+            }
             label="중복 확인"
             onClick={handleCheckNickname}
-            disabled={!!errors.nickname || nicknameVal.trim().length === 0 || isSubmitting}
-            className="cap_14_sb mt-[0.8rem] w-auto px-[1.6rem] py-[0.6rem] disabled:text-white"
+            className={cn(
+              'cap_14_sb mt-[0.8rem] w-auto px-[1.6rem] py-[0.6rem]',
+              (!!errors.nickname || nicknameVal.trim().length === 0 || isSubmitting) &&
+                'cursor-not-allowed',
+            )}
           />
           <Button
             type="button"
+            variant={
+              nicknameStatus !== 'available' || nicknameVal.trim().length === 0 || isSubmitting
+                ? 'disabled'
+                : 'blue'
+            }
             label="수정"
             onClick={submitNickname}
-            disabled={
-              nicknameStatus !== 'available' || nicknameVal.trim().length === 0 || isSubmitting
-            }
-            className="cap_14_sb mt-[0.8rem] w-auto px-[1.6rem] py-[0.6rem]"
+            className={cn(
+              'cap_14_sb mt-[0.8rem] w-auto px-[1.6rem] py-[0.6rem]',
+              (nicknameStatus !== 'available' || nicknameVal.trim().length === 0 || isSubmitting) &&
+                'cursor-not-allowed',
+            )}
           />
         </div>
 
@@ -188,10 +201,18 @@ const EditProfile = () => {
         <div className="flex justify-end">
           <Button
             type="button"
+            variant={
+              !!errors.introduction || introductionVal.trim().length === 0 || isSubmitting
+                ? 'disabled'
+                : 'blue'
+            }
             label="수정"
             onClick={submitInformation}
-            disabled={!!errors.introduction || introductionVal.trim().length === 0 || isSubmitting}
-            className="cap_14_sb mt-[0.8rem] w-auto px-[1.6rem] py-[0.6rem]"
+            className={cn(
+              'cap_14_sb mt-[0.8rem] w-auto px-[1.6rem] py-[0.6rem]',
+              (!!errors.introduction || introductionVal.trim().length === 0 || isSubmitting) &&
+                'cursor-not-allowed',
+            )}
           />
         </div>
       </section>

--- a/src/pages/profile/profile.tsx
+++ b/src/pages/profile/profile.tsx
@@ -38,37 +38,38 @@ const Profile = () => {
           label="프로필 · 매칭 조건 수정"
           onClick={() => navigate(ROUTES.PROFILE_EDIT)}
         />
+        <Divider thickness={0.4} color="bg-gray-200" />
+        <section className="w-full flex-col items-start">
+          <a
+            href={REQUEST_LINK}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="문의하기"
+            className="cap_14_m py-[0.8rem] text-gray-800"
+          >
+            문의하기
+          </a>
+          <a
+            href={FEEDBACK_LINK}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="의견 보내기"
+            className="cap_14_m py-[0.8rem] text-gray-800"
+          >
+            의견 보내기
+          </a>
+          <Divider color="bg-gray-300" margin="my-[1.6rem]" />
+          <button
+            type="button"
+            onClick={() => logout()}
+            aria-label="로그아웃"
+            className="cap_14_m cursor-pointer py-[0.8rem] text-gray-800"
+          >
+            <p>로그아웃</p>
+          </button>
+        </section>
       </div>
-      <Divider thickness={0.4} color="bg-gray-200" />
-      <section className="w-full flex-col items-start px-[1.6rem]">
-        <a
-          href={REQUEST_LINK}
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label="문의하기"
-          className="cap_14_m py-[0.8rem] text-gray-800"
-        >
-          문의하기
-        </a>
-        <a
-          href={FEEDBACK_LINK}
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label="의견 보내기"
-          className="cap_14_m py-[0.8rem] text-gray-800"
-        >
-          의견 보내기
-        </a>
-        <Divider color="bg-gray-300" margin="my-[1.6rem]" />
-        <button
-          type="button"
-          onClick={() => logout()}
-          aria-label="로그아웃"
-          className="cap_14_m cursor-pointer py-[0.8rem] text-gray-800"
-        >
-          <p>로그아웃</p>
-        </button>
-      </section>
+
       <Footer />
     </div>
   );

--- a/src/shared/components/button/button/styles/button-variants.ts
+++ b/src/shared/components/button/button/styles/button-variants.ts
@@ -11,7 +11,7 @@ export const buttonVariants = cva(
         white: 'bg-white text-gray-700',
         skyblueBorder: 'bg-main-200 text-main-900 outline outline-main-900',
         gray2: 'bg-background text-gray-700',
-        disabled: 'bg-gray-100 text-gray-400',
+        disabled: 'rounded-[0.8rem] bg-gray-100 bg-gray-100 text-gray-400',
       },
       size: {
         M: 'w-full px-[0.8rem] py-[1.2rem]',

--- a/src/shared/components/input/input.tsx
+++ b/src/shared/components/input/input.tsx
@@ -44,6 +44,12 @@ const Input = ({
   const borderClass = inputClassMap[inputState];
   const iconColorClass = iconColorMap[inputState];
 
+  const helperIconName = multiline
+    ? 'info-filled'
+    : inputState === 'valid'
+      ? 'check-filled'
+      : 'info-filled';
+
   return (
     <div className="flex-col gap-[0.8rem]">
       {label && (
@@ -92,7 +98,7 @@ const Input = ({
       {messageToShow && (
         <div className="flex-row gap-[0.8rem]">
           <Icon
-            name={inputState === 'valid' ? 'check-filled' : 'info-filled'}
+            name={helperIconName}
             size={2}
             className={cn('text-gray-600', !multiline && iconColorClass)}
           />


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #363 

## 💎 PR Point
- 마이페이지 내부 Divider, 문의하기, 의견보내기, 로그아웃 모두 상단으로 고정
- 중복확인/수정 버튼의 disabled 스타일 반영
- 한줄 소개 텍스트필드 아래 Icon Info로 고정시킴

## 📸 Screenshot
<img width="271" height="791" alt="image" src="https://github.com/user-attachments/assets/2d45fa1e-3284-4c01-88b5-a1f3053381af" />
<img width="276" height="758" alt="image" src="https://github.com/user-attachments/assets/1ef81d2b-ea8a-482b-8033-7aec19516021" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 비활성화 버튼의 시각 스타일을 통일하고 모서리 라운드 및 ‘금지’ 커서 표시로 사용성 개선.
  - 닉네임/소개/매칭 조건 버튼의 비활성화 상태가 더 분명하게 표현됨.
  - 프로필 페이지 하단 액션 영역(문의/의견/로그아웃) 좌우 여백 제거로 레이아웃 정돈.
  - 멀티라인 입력 필드의 보조 아이콘을 항상 정보 아이콘으로 표시해 상태 아이콘 표기를 일관화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->