### PR TITLE
fix: (QA/3) dim scroll 문제 해결

### DIFF
--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -17,7 +17,7 @@ import { useQuery } from '@tanstack/react-query';
 import { addDays, format } from 'date-fns';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { toggleScrollLock } from '@/shared/utils/scroll-lock';
+import { handleScrollLock } from '@/shared/utils/scroll-lock';
 
 const Home = () => {
   const { activeType, changeTab, isSingle, isGroup } = useTabState();
@@ -40,15 +40,7 @@ const Home = () => {
 
   const { needsMatchingSetup } = useAuth();
 
-  useEffect(() => {
-    toggleScrollLock(needsMatchingSetup);
-
-    return () => {
-      if (needsMatchingSetup) {
-        toggleScrollLock(false);
-      }
-    };
-  }, [needsMatchingSetup]);
+  handleScrollLock(needsMatchingSetup);
 
   useEffect(() => {
     const from = needsMatchingSetup ? 'onboarding' : 'return_user';

--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -17,6 +17,7 @@ import { useQuery } from '@tanstack/react-query';
 import { addDays, format } from 'date-fns';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { toggleScrollLock } from '@/shared/utils/scroll-lock';
 
 const Home = () => {
   const { activeType, changeTab, isSingle, isGroup } = useTabState();
@@ -38,6 +39,16 @@ const Home = () => {
   });
 
   const { needsMatchingSetup } = useAuth();
+
+  useEffect(() => {
+    toggleScrollLock(needsMatchingSetup);
+
+    return () => {
+      if (needsMatchingSetup) {
+        toggleScrollLock(false);
+      }
+    };
+  }, [needsMatchingSetup]);
 
   useEffect(() => {
     const from = needsMatchingSetup ? 'onboarding' : 'return_user';

--- a/src/shared/components/bottom-sheet/bottom-sheet.tsx
+++ b/src/shared/components/bottom-sheet/bottom-sheet.tsx
@@ -2,8 +2,9 @@ import BottomSheetIndicator from '@components/bottom-sheet/bottom-sheet-indicato
 import useOutsideClick from '@components/bottom-sheet/hooks/use-outside-click';
 import { cn } from '@libs/cn';
 import { AnimatePresence, motion } from 'framer-motion';
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
+import { toggleScrollLock } from '@/shared/utils/scroll-lock';
 
 interface BottomSheetProps {
   isOpen: boolean;
@@ -24,6 +25,16 @@ const BottomSheet = ({
 }: BottomSheetProps) => {
   const sheetRef = useRef<HTMLDivElement>(null);
   useOutsideClick(sheetRef, onClose);
+
+  useEffect(() => {
+    toggleScrollLock(isOpen);
+
+    return () => {
+      if (isOpen) {
+        toggleScrollLock(false);
+      }
+    };
+  }, [isOpen]);
 
   return createPortal(
     <AnimatePresence>

--- a/src/shared/components/bottom-sheet/bottom-sheet.tsx
+++ b/src/shared/components/bottom-sheet/bottom-sheet.tsx
@@ -2,9 +2,9 @@ import BottomSheetIndicator from '@components/bottom-sheet/bottom-sheet-indicato
 import useOutsideClick from '@components/bottom-sheet/hooks/use-outside-click';
 import { cn } from '@libs/cn';
 import { AnimatePresence, motion } from 'framer-motion';
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 import { createPortal } from 'react-dom';
-import { toggleScrollLock } from '@/shared/utils/scroll-lock';
+import { handleScrollLock } from '@/shared/utils/scroll-lock';
 
 interface BottomSheetProps {
   isOpen: boolean;
@@ -26,15 +26,7 @@ const BottomSheet = ({
   const sheetRef = useRef<HTMLDivElement>(null);
   useOutsideClick(sheetRef, onClose);
 
-  useEffect(() => {
-    toggleScrollLock(isOpen);
-
-    return () => {
-      if (isOpen) {
-        toggleScrollLock(false);
-      }
-    };
-  }, [isOpen]);
+  handleScrollLock(isOpen);
 
   return createPortal(
     <AnimatePresence>

--- a/src/shared/styles/global.css
+++ b/src/shared/styles/global.css
@@ -46,4 +46,11 @@
   body::-webkit-scrollbar {
     display: none; /* Chrome, Safari */
   }
+
+  body.scroll-locked {
+    position: fixed;
+    width: 100%;
+    overflow: hidden;
+    -webkit-overflow-scrolling: touch;
+  }
 }

--- a/src/shared/styles/global.css
+++ b/src/shared/styles/global.css
@@ -46,11 +46,4 @@
   body::-webkit-scrollbar {
     display: none; /* Chrome, Safari */
   }
-
-  body.scroll-locked {
-    position: fixed;
-    width: 100%;
-    overflow: hidden;
-    -webkit-overflow-scrolling: touch;
-  }
 }

--- a/src/shared/utils/scroll-lock.ts
+++ b/src/shared/utils/scroll-lock.ts
@@ -1,21 +1,9 @@
-let scrollPosition = 0;
-
-export const lockScroll = () => {
-  scrollPosition = window.scrollY;
-  document.body.classList.add('scroll-locked');
-  document.body.style.top = `-${scrollPosition}px`;
-};
-
-export const unlockScroll = () => {
-  document.body.classList.remove('scroll-locked');
-  document.body.style.top = '';
-  window.scrollTo(0, scrollPosition);
-};
-
-export const toggleScrollLock = (isOpen: boolean) => {
+export const handleScrollLock = (isOpen: boolean) => {
   if (isOpen) {
-    lockScroll();
+    document.body.style.overflow = 'hidden';
+    document.body.style.touchAction = 'none';
   } else {
-    unlockScroll();
+    document.body.style.removeProperty('overflow');
+    document.body.style.removeProperty('touch-action');
   }
 };

--- a/src/shared/utils/scroll-lock.ts
+++ b/src/shared/utils/scroll-lock.ts
@@ -1,0 +1,21 @@
+let scrollPosition = 0;
+
+export const lockScroll = () => {
+  scrollPosition = window.scrollY;
+  document.body.classList.add('scroll-locked');
+  document.body.style.top = `-${scrollPosition}px`;
+};
+
+export const unlockScroll = () => {
+  document.body.classList.remove('scroll-locked');
+  document.body.style.top = '';
+  window.scrollTo(0, scrollPosition);
+};
+
+export const toggleScrollLock = (isOpen: boolean) => {
+  if (isOpen) {
+    lockScroll();
+  } else {
+    unlockScroll();
+  }
+};


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #367 


## 💎 PR Point

1. 스크롤 방지 유틸리티 함수 구현 (src/shared/utils/scroll-lock.ts)
```
export const handleScrollLock = (isOpen: boolean) => {
  if (isOpen) {
    document.body.style.overflow = 'hidden';
    document.body.style.touchAction = 'none';
  } else {
    document.body.style.removeProperty('overflow');
    document.body.style.removeProperty('touch-action');
  }
};
```
overflow: hidden: 스크롤바를 완전히 숨기고 스크롤 방지
touchAction: none: 모바일에서 모든 터치 제스처(스크롤, 줌, 팬 등) 비활성화
removeProperty(): 스타일 속성을 완전히 제거하여 원래 상태로 복원

2. BottomSheet 컴포넌트에 스크롤 방지 적용
```
handleScrollLock(isOpen);
```
3. 홈 페이지 모달에 스크롤 방지 적용
```
handleScrollLock(needsMatchingSetup);
```



## 📸 Screenshot
개발자 모드에서는 확인이 불가해서 배포하고 폰으로 확인 해봐야 할 것 같아요ㅜㅜ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 바텀시트가 열려 있을 때 페이지 배경 스크롤이 자동으로 잠겨 사용자 인터랙션이 안정화되었습니다.
  - 홈 화면에서도 특정 설정 단계에서 스크롤 잠금을 적용해 의도치 않은 화면 이동을 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->