### PR TITLE
feat: (QA/3) 그룹 매칭 수락 완료 화면의 뒤로가기 버튼 삭제 

### DIFF
--- a/src/pages/result/components/matching-agree-view.tsx
+++ b/src/pages/result/components/matching-agree-view.tsx
@@ -2,11 +2,10 @@ import { matchQueries } from '@apis/match/match-queries';
 import Button from '@components/button/button/button';
 import MatchCurrentCard from '@components/card/match-current-card/match-current-card';
 import { LOTTIE_PATH } from '@constants/lotties';
-import usePreventBackNavigation from '@hooks/use-prevent-back-navigation';
 import { ROUTES } from '@routes/routes-config';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Lottie } from '@toss/lottie';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 interface MatchingAgreeViewProps {
   matchId: string;
@@ -14,11 +13,6 @@ interface MatchingAgreeViewProps {
 
 const MatchingAgreeView = ({ matchId }: MatchingAgreeViewProps) => {
   const navigate = useNavigate();
-  const [params] = useSearchParams();
-  const cardType = params.get('cardtype');
-  usePreventBackNavigation(
-    `${ROUTES.MATCH}?tab=${cardType === 'group' ? '그룹' : '1:1'}&filter=전체`,
-  );
 
   const { data: agreeData } = useSuspenseQuery(matchQueries.COUNTED_MEMBER(Number(matchId)));
   const matchedCount = agreeData?.count;

--- a/src/shared/components/header/utils/get-header.tsx
+++ b/src/shared/components/header/utils/get-header.tsx
@@ -42,8 +42,7 @@ export const getHeaderContent = (
   };
 
   const isResult = Boolean(matchPath(`${ROUTES.RESULT()}`, pathname));
-  const isGroupAgree =
-    isResult && urlParams.get('type') === 'agree';
+  const isGroupAgree = isResult && urlParams.get('type') === 'agree';
   if (isGroupAgree) {
     return null;
   }

--- a/src/shared/components/header/utils/get-header.tsx
+++ b/src/shared/components/header/utils/get-header.tsx
@@ -25,12 +25,10 @@ export const getHeaderContent = (
         navigate(ROUTES.HOME);
         return;
       }
-
       if (goMatchTypes.includes(type)) {
         navigate(ROUTES.MATCH);
         return;
       }
-
       if (isCreate) {
         return null;
       }
@@ -42,6 +40,13 @@ export const getHeaderContent = (
   const handleChatClick = () => {
     navigate(ROUTES.CHAT);
   };
+
+  const isResult = Boolean(matchPath(`${ROUTES.RESULT()}`, pathname));
+  const isGroupAgree =
+    isResult && urlParams.get('type') === 'agree';
+  if (isGroupAgree) {
+    return null;
+  }
 
   if (pathname === ROUTES.HOME) {
     return (


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #343

## ☀️ New-insight

**결과 화면(`/result/:id`)에서 `type=agree`인 경우 헤더 자체를 렌더링하지 않도록** 헤더 로직을 변경하고, 이 변경에 따라 **개별 화면 컴포넌트 내부에서 사용하던 뒤로가기 가드 훅을 제거**했습니다.

## 💎 PR Point

기존에는 결과 화면에서도 헤더가 공통으로 노출되며 뒤로가기 아이콘/가드 훅으로 네비게이션을 제어했습니다. 이번 작업에서는 그룹 매칭 수락 완료 화면 내 사용자의 혼란을 방지하기 위해 따라서 헤더 단계에서 `type=agree`를 감지해 헤더를 숨김 처리하고, 페이지 내부의 usePreventBackNavigation 훅을 제거해 중복 제어를 없앴습니다.


1. **헤더 로직 추가**: `pathname`이 결과 경로이고 `type=agree`이면 `null`을 반환하여 헤더 비노출
2. **페이지 내부 정리**: 헤더가 사라지므로 뒤로가기 동작을 가드할 필요가 없어져 `usePreventBackNavigation` 훅 제거


### 1) Header: `getHeaderContent`에 agree 분기 추가

```tsx
  const isResult = Boolean(matchPath(`${ROUTES.RESULT()}`, pathname));
  const isGroupAgree = isResult && urlParams.get('type') === 'agree';
  if (isGroupAgree) {
    return null;
  }
```

### 2) 결과-수락 완료 화면: 컴포넌트에서 뒤로가기 훅 제거
usePreventBackNavigation 


* `https://dev.mateball.co.kr/result/69?type=agree&cardtype=group` → **헤더가 노출되지 않음**
* 뒤로가기는 상단 아이콘 대신 **화면 내 CTA(예: ‘매칭 현황 보기’ 버튼)** 로 유도
* 결과적으로 **헤더/페이지 양쪽에서 중복 제어하던 네비게이션 로직을 헤더 한 곳으로 정리**하여 일관성 향상




## 📸 Screenshot
<img width="300" alt="화면 캡처 2025-09-07 203217" src="https://github.com/user-attachments/assets/f725e92b-41fa-416f-a2d5-9a899ea32fbe" />
