### PR TITLE
fix: (QA/3) 온보딩 뒤로가기 분기처리 

### DIFF
--- a/src/pages/onboarding/onboarding.tsx
+++ b/src/pages/onboarding/onboarding.tsx
@@ -45,10 +45,18 @@ const Onboarding = () => {
 
   const { mutate } = useMutation(matchMutations.MATCH_CONDITION());
 
+  const handlePrev = () => {
+    if (currentStep === 'VIEWING_STYLE' && selections.SUPPORT_TEAM === NO_TEAM_OPTION) {
+      goTo('SUPPORT_TEAM');
+    } else {
+      goPrev();
+    }
+  };
+
   return (
     <div className="h-full flex-col">
       <div className="sticky top-0 bg-background">
-        <OnboardingHeader onClick={goPrev} />
+        <OnboardingHeader onClick={handlePrev} />
         {currentStep !== 'START' && (
           <div className="w-full">
             <ProgressBar

--- a/src/pages/result/components/matching-agree-view.tsx
+++ b/src/pages/result/components/matching-agree-view.tsx
@@ -5,7 +5,7 @@ import { LOTTIE_PATH } from '@constants/lotties';
 import { ROUTES } from '@routes/routes-config';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Lottie } from '@toss/lottie';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 interface MatchingAgreeViewProps {
   matchId: string;
@@ -13,6 +13,8 @@ interface MatchingAgreeViewProps {
 
 const MatchingAgreeView = ({ matchId }: MatchingAgreeViewProps) => {
   const navigate = useNavigate();
+  const [params] = useSearchParams();
+  const cardType = params.get('cardtype');
 
   const { data: agreeData } = useSuspenseQuery(matchQueries.COUNTED_MEMBER(Number(matchId)));
   const matchedCount = agreeData?.count;


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #372 

## ☀️ New-insight

응원하는 팀이 없어서 SYNC 단계를 건너뛰었는데, 뒤로가면 바로 전 단계로 넘어가는 문제가 있엇슨

## 💎 PR Point

- 응원하는 팀이 없는 경우 뒤로가기도 건너뛸 수 있게 수정

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 버그 수정
  - 온보딩 뒤로 가기 동작을 개선했습니다. 특정 단계에서 지원팀을 선택하지 않은 경우 이전이 아닌 지원팀 선택 단계로 정확히 이동하도록 하여 화면 전환 일관성과 입력 보존을 향상시켰습니다.

- 새 기능
  - 결과 화면의 "매칭 현황 보기" 버튼이 URL의 cardtype 쿼리값을 읽어 기본 탭을 결정합니다(값이 'group'이면 그룹 탭, 그 외는 1:1 탭; 쿼리 미존재 시 1:1 기본).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->