### PR TITLE
feat: SP1 알림배지 제거 api 연결

### DIFF
--- a/src/pages/result/components/matching-receive-view.tsx
+++ b/src/pages/result/components/matching-receive-view.tsx
@@ -1,4 +1,3 @@
-import { alarmMutations } from '@apis/alarm/alarm-mutations';
 import { matchMutations } from '@apis/match/match-mutations';
 import { matchQueries } from '@apis/match/match-queries';
 import Button from '@components/button/button/button';
@@ -27,7 +26,6 @@ const MatchingReceiveView = () => {
 
   const parsedId = Number(matchId);
   const { mutate: acceptMatch } = useMutation(matchMutations.MATCH_ACCEPT());
-  const { mutate: readAlarm } = useMutation(alarmMutations.READ_ALARM());
   const { mutate: rejectMatch } = useMutation(matchMutations.MATCH_REJECT());
   const { data, isError } = useQuery(matchQueries.MATCH_DETAIL(parsedId, true));
 
@@ -62,18 +60,11 @@ const MatchingReceiveView = () => {
   const handleAccept = () => {
     acceptMatch(parsedId, {
       onSuccess: () => {
-        readAlarm(parsedId, {
-          onSuccess: () => {
-            if (cardType === 'group') {
-              navigate(`${ROUTES.MATCH}?tab=그룹&filter=전체`);
-            } else {
-              navigate(`${ROUTES.RESULT(matchId)}?type=success`);
-            }
-          },
-          onError: () => {
-            navigate(ROUTES.ERROR);
-          },
-        });
+        if (isGroupMatching) {
+          navigate(`${ROUTES.MATCH}?tab=그룹&filter=전체`);
+        } else {
+          navigate(`${ROUTES.RESULT(matchId)}?type=success`);
+        }
 
         fillTabItems.forEach((label) => {
           queryClient.invalidateQueries({ queryKey: MATCH_KEY.STATUS.SINGLE(label) });

--- a/src/shared/apis/alarm/alarm-mutations.ts
+++ b/src/shared/apis/alarm/alarm-mutations.ts
@@ -3,18 +3,8 @@ import { END_POINT } from '@constants/api';
 import { ALARM_KEY } from '@constants/query-key';
 import queryClient from '@libs/query-client';
 import { mutationOptions } from '@tanstack/react-query';
-import type { postReadAlarmResponse } from '@/shared/types/alarm-types';
 
 export const alarmMutations = {
-  READ_ALARM: () =>
-    mutationOptions<postReadAlarmResponse, Error, number>({
-      mutationKey: ALARM_KEY.READ(),
-      mutationFn: (matchId) => post(END_POINT.POST_READ_ALARM(matchId)),
-      onSuccess: () => {
-        queryClient.invalidateQueries({ queryKey: ALARM_KEY.HAS_UNREAD });
-      },
-    }),
-
   READ_ALL_ALARMS: () =>
     mutationOptions<Error, void>({
       mutationKey: ALARM_KEY.READ_ALL(),

--- a/src/shared/apis/alarm/alarm-mutations.ts
+++ b/src/shared/apis/alarm/alarm-mutations.ts
@@ -14,4 +14,13 @@ export const alarmMutations = {
         queryClient.invalidateQueries({ queryKey: ALARM_KEY.HAS_UNREAD });
       },
     }),
+
+  READ_ALL_ALARMS: () =>
+    mutationOptions<Error, void>({
+      mutationKey: ALARM_KEY.READ_ALL(),
+      mutationFn: () => post(END_POINT.POST_READ_ALL_ALARMS),
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ALARM_KEY.HAS_UNREAD });
+      },
+    }),
 };

--- a/src/shared/apis/alarm/alarm-mutations.ts
+++ b/src/shared/apis/alarm/alarm-mutations.ts
@@ -6,9 +6,12 @@ import { mutationOptions } from '@tanstack/react-query';
 
 export const alarmMutations = {
   READ_ALL_ALARMS: () =>
-    mutationOptions<Error, void>({
+    mutationOptions<void, Error, void>({
       mutationKey: ALARM_KEY.READ_ALL(),
-      mutationFn: () => post(END_POINT.POST_READ_ALL_ALARMS),
+      mutationFn: () => post<void>(END_POINT.POST_READ_ALL_ALARMS),
+      onMutate: async () => {
+        queryClient.setQueryData(ALARM_KEY.HAS_UNREAD, false);
+      },
       onSuccess: () => {
         queryClient.invalidateQueries({ queryKey: ALARM_KEY.HAS_UNREAD });
       },

--- a/src/shared/components/bottom-navigation/bottom-navigation.tsx
+++ b/src/shared/components/bottom-navigation/bottom-navigation.tsx
@@ -1,10 +1,11 @@
+import { alarmMutations } from '@apis/alarm/alarm-mutations';
 import { alarmQueries } from '@apis/alarm/alarm-queries';
 import { NAV_ITEMS } from '@components/bottom-navigation/constants/bottom-navigation';
 import Icon from '@components/icon/icon';
 import useAuth from '@hooks/use-auth';
 import { cn } from '@libs/cn';
 import { ROUTES } from '@routes/routes-config';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 const BottomNavigation = () => {
@@ -14,6 +15,8 @@ const BottomNavigation = () => {
 
   const { data: hasUnreadAlarms } = useQuery(alarmQueries.HAS_UNREAD());
 
+  const readAllAlarmsMutation = useMutation(alarmMutations.READ_ALL_ALARMS());
+
   const isActive = (path: string) => pathname === path;
 
   const isDisabled = (path: string) => {
@@ -22,6 +25,11 @@ const BottomNavigation = () => {
 
   const handleTabClick = (path: string) => {
     if (isDisabled(path)) return;
+
+    if (path === ROUTES.MATCH && hasUnreadAlarms) {
+      readAllAlarmsMutation.mutate();
+    }
+
     navigate(path);
   };
 

--- a/src/shared/constants/api.ts
+++ b/src/shared/constants/api.ts
@@ -48,4 +48,5 @@ export const END_POINT = {
   // 알림
   GET_UNREAD_ALARMS: '/v2/users/alarm',
   POST_READ_ALARM: (matchId: number | string) => `/v2/users/alarm/${matchId}`,
+  POST_READ_ALL_ALARMS: '/v2/users/alarms',
 };

--- a/src/shared/constants/query-key.ts
+++ b/src/shared/constants/query-key.ts
@@ -66,6 +66,5 @@ export const MATCH_KEY = {
 
 export const ALARM_KEY = {
   HAS_UNREAD: ['alarms', 'hasUnread'] as const,
-  READ: () => ['alarms', 'read'] as const,
   READ_ALL: () => ['alarms', 'read-all'] as const,
 };

--- a/src/shared/constants/query-key.ts
+++ b/src/shared/constants/query-key.ts
@@ -67,4 +67,5 @@ export const MATCH_KEY = {
 export const ALARM_KEY = {
   HAS_UNREAD: ['alarms', 'hasUnread'] as const,
   READ: () => ['alarms', 'read'] as const,
+  READ_ALL: () => ['alarms', 'read-all'] as const,
 };


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #378 

## 💎 PR Point

- 기존 로직('요청 수락하기', '채팅방 입장하기' 버튼 클릭 시 알림배지 제거) 삭제
- 매칭 현황 탭 클릭 시 알림배지 제거

## 📸 Screenshot

https://github.com/user-attachments/assets/a0262bfb-5f8e-47c7-a6e0-b099221dd124



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 매칭 탭으로 이동할 때 읽지 않은 알림이 있으면 자동으로 전체 읽음 처리되어 알림 배지가 즉시 정리됩니다.
  * 매칭 수락 후 상황에 따라 바로 적절한 화면으로 이동합니다: 그룹 매칭은 그룹 경로로, 1:1 매칭은 성공 화면으로 안내됩니다.
  * 매칭 수락 이후 단일·그룹 매칭 상태를 모두 새로고침하여 관련 화면의 정보가 즉시 최신 상태로 반영됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->