### PR TITLE
fix: (QA/3) 온보딩 뒤로가기 분기처리

### DIFF
--- a/src/pages/onboarding/onboarding-group.tsx
+++ b/src/pages/onboarding/onboarding-group.tsx
@@ -31,10 +31,19 @@ const OnboardingGroup = () => {
     setSelection((prev) => ({ ...prev, [stepName]: value }));
   };
 
+  const handlePrev = () => {
+    if (currentStep === 'GROUP_ROLE' || currentStep === 'COMPLETE') {
+      navigate(ROUTES.HOME);
+      return;
+    }
+
+    goPrev();
+  };
+
   return (
     <div className="h-full flex-col">
       <div className="sticky top-0 bg-background">
-        <OnboardingHeader onClick={goPrev} />
+        <OnboardingHeader onClick={handlePrev} />
         {currentStep !== 'START' && (
           <div className="w-full">
             <ProgressBar currentStep={currentIndex} totalSteps={steps.length - 1} />

--- a/src/pages/onboarding/onboarding.tsx
+++ b/src/pages/onboarding/onboarding.tsx
@@ -46,6 +46,11 @@ const Onboarding = () => {
   const { mutate } = useMutation(matchMutations.MATCH_CONDITION());
 
   const handlePrev = () => {
+    if (currentStep === 'COMPLETE') {
+      navigate(ROUTES.HOME);
+      return;
+    }
+
     if (currentStep === 'VIEWING_STYLE' && selections.SUPPORT_TEAM === NO_TEAM_OPTION) {
       goTo('SUPPORT_TEAM');
     } else {


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #380 

## ☀️ New-insight

분기처리 개많다 진짜.....
온보딩 지옥임
![D2203CFF-AF2E-41AC-95E6-BCF4328BFC66](https://github.com/user-attachments/assets/59738a96-5939-4b63-8984-8c1b107008c4)


## 💎 PR Point

완료화면, 그룹역할 선택화면, 그룹원 완료화면에서 뒤로가기 클릭시 홈화면으로 이동합니다~

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 온보딩 ‘완료’ 단계에서 뒤로가기 시 이전 단계로 돌아가던 동작을 수정하여, 홈으로 이동하도록 변경했습니다.
  * 그룹 역할 선택 단계에서도 뒤로가기 시 홈으로 이동하도록 동작을 통일했습니다.
  * 불필요한 단계 이동이나 루프를 방지해 온보딩 종료 흐름이 더 명확하고 예측 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->