### PR TITLE
fix: (QA/3) 홈으로 페이지 이동할 때 배너 이미지 로드 전에 텍스트만 뜨는 문제 해결 

### DIFF
--- a/src/shared/components/card/banner-card/banner-card.tsx
+++ b/src/shared/components/card/banner-card/banner-card.tsx
@@ -14,7 +14,12 @@ const BannerCard = ({ text, subText, onClick }: CardBannerProps) => {
 
   return (
     <button type="button" className={cn('relative cursor-pointer text-left')} onClick={onClick}>
-      <img src={BannerImg} alt="홈배너" className="w-full" onLoad={() => setImageLoaded(true)} />
+      <img
+        src={BannerImg}
+        alt="홈배너"
+        className="min-h-[9.6rem] w-full"
+        onLoad={() => setImageLoaded(true)}
+      />
       {imageLoaded && (
         <div className="absolute inset-0 flex flex-col justify-center gap-[0.4rem] py-[2.2rem] pl-[2.4rem]">
           <p className="cap_14_m text-gray-800">{subText}</p>


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #384 


## 💎 PR Point

홈으로 페이지 이동할 때, 상단 카드 배너 이미지가 로드 되지 않은 상태에서 이용 가이드 보러가기 텍스트가 먼저 로드 되어서 생기는 문제를 해결하고자 카드 배너에 로드 상태를 추가했습니다.

## 📸 Screenshot
<img width="394" height="720" alt="image" src="https://github.com/user-attachments/assets/cfb554ea-6e4a-4fd0-bfd4-fabb83b1f73f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 배너 이미지가 완전히 로드된 후에만 캡션 오버레이를 표시하여 초기 깜빡임과 레이아웃 이동을 줄였습니다.
* **Style**
  * 캡션 레이아웃에 flex를 적용해 정렬성과 가독성을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->