### PR TITLE
fix: 회원가입 design, gaEvent 수정 및 매칭 현황 내 중복 데이터 오류 해결

### DIFF
--- a/src/pages/match/components/match-tab-pannel.tsx
+++ b/src/pages/match/components/match-tab-pannel.tsx
@@ -1,4 +1,3 @@
-// src/pages/match/components/match-tab-pannel.tsx
 import { matchMutations } from '@apis/match/match-mutations';
 import { matchQueries } from '@apis/match/match-queries';
 import Card from '@components/card/match-card/card';

--- a/src/pages/match/components/match-tab-pannel.tsx
+++ b/src/pages/match/components/match-tab-pannel.tsx
@@ -1,11 +1,12 @@
+// src/pages/match/components/match-tab-pannel.tsx
 import { matchMutations } from '@apis/match/match-mutations';
+import { matchQueries } from '@apis/match/match-queries';
 import Card from '@components/card/match-card/card';
 import type { GroupCardProps, SingleCardProps } from '@components/card/match-card/types/card';
 import { getColorType } from '@components/card/match-card/utils/get-color-type';
 import EmptyView from '@components/ui/empty-view';
 import { cn } from '@libs/cn';
 import { CLICKABLE_STATUS_MAP } from '@pages/match/constants/matching';
-import type { MatchCardData } from '@pages/match/create/types/match-data-type';
 import {
   getCardColor,
   getPendingToast,
@@ -13,25 +14,42 @@ import {
   statusToCategory,
 } from '@pages/match/utils/match-status';
 import { ROUTES } from '@routes/routes-config';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { showErrorToast } from '@/shared/utils/show-error-toast';
+import { mapGroupMatchData, mapSingleMatchData } from '../hooks/mapMatchData';
 
 type MatchableCardProps = SingleCardProps | GroupCardProps;
 
 interface MatchTabPanelProps {
-  cards: MatchableCardProps[];
+  activeType: '1:1' | '그룹';
+  statusParam: string;
   filter: string;
-  onCardClick: (card: MatchCardData) => void;
+  onCardClick: (card: MatchableCardProps) => void;
 }
 
-const MatchTabPanel = ({ cards, filter, onCardClick }: MatchTabPanelProps) => {
+const MatchTabPanel = ({ activeType, filter, statusParam, onCardClick }: MatchTabPanelProps) => {
   const navigate = useNavigate();
+  const isSingle = activeType === '1:1';
 
-  const patchStageMutation = useMutation(matchMutations.MATCH_STAGE());
+  const { data: singleData } = useQuery({
+    ...matchQueries.SINGLE_MATCH_STATUS(statusParam),
+    enabled: isSingle,
+  });
+
+  const { data: groupData } = useQuery({
+    ...matchQueries.GROUP_MATCH_STATUS(statusParam),
+    enabled: !isSingle,
+  });
+
+  const cards: MatchableCardProps[] = isSingle
+    ? mapSingleMatchData(singleData?.results)
+    : mapGroupMatchData(groupData?.mates);
 
   const filteredCards =
     filter === '전체' ? cards : cards.filter((card) => statusToCategory(card.status) === filter);
+
+  const patchStageMutation = useMutation(matchMutations.MATCH_STAGE());
 
   const handleCardClick = async (card: MatchableCardProps) => {
     onCardClick(card);
@@ -70,9 +88,7 @@ const MatchTabPanel = ({ cards, filter, onCardClick }: MatchTabPanelProps) => {
             key={card.id}
             type="button"
             onClick={() => handleCardClick(card)}
-            className={cn('w-full', {
-              'cursor-pointer': isClickable(card.status),
-            })}
+            className={cn('w-full', { 'cursor-pointer': isClickable(card.status) })}
             aria-disabled={!isClickable(card.status)}
           >
             <Card

--- a/src/pages/match/match.tsx
+++ b/src/pages/match/match.tsx
@@ -8,7 +8,6 @@ import { mapGroupMatchData, mapSingleMatchData } from '@pages/match/hooks/mapMat
 import { useMatchTabState } from '@pages/match/hooks/useMatchTabState';
 import { fillTabItems } from '@pages/match/utils/match-status';
 import { useQuery } from '@tanstack/react-query';
-import { useEffect } from 'react';
 import type { MatchCardData } from './create/types/match-data-type';
 
 const Match = () => {
@@ -25,26 +24,6 @@ const Match = () => {
     ...matchQueries.GROUP_MATCH_STATUS(statusParam),
     enabled: activeType === '그룹',
   });
-
-  useEffect(() => {
-    if (activeType === '1:1' && singleData?.results) {
-      singleData.results.forEach((card) => {
-        gaEvent('match_card_view', {
-          match_id: card.id,
-          match_type: 'one_to_one',
-          match_status: card.status,
-        });
-      });
-    } else if (activeType === '그룹' && groupData?.mates) {
-      groupData.mates.forEach((card) => {
-        gaEvent('match_card_view', {
-          match_id: card.id,
-          match_type: 'group',
-          match_status: card.status,
-        });
-      });
-    }
-  }, [singleData, groupData, activeType]);
 
   const handleCardClick = (card: MatchCardData) => {
     gaEvent('match_card_click', {

--- a/src/pages/match/match.tsx
+++ b/src/pages/match/match.tsx
@@ -1,13 +1,9 @@
-import { matchQueries } from '@apis/match/match-queries';
 import FillTabList from '@components/tab/fill-tab/fill-tab-list';
-import TabContent from '@components/tab/tab/tab-content';
 import TabList from '@components/tab/tab/tab-list';
 import { gaEvent } from '@libs/analytics';
 import MatchTabPanel from '@pages/match/components/match-tab-pannel';
-import { mapGroupMatchData, mapSingleMatchData } from '@pages/match/hooks/mapMatchData';
 import { useMatchTabState } from '@pages/match/hooks/useMatchTabState';
 import { fillTabItems } from '@pages/match/utils/match-status';
-import { useQuery } from '@tanstack/react-query';
 import type { MatchCardData } from './create/types/match-data-type';
 
 const Match = () => {
@@ -15,41 +11,12 @@ const Match = () => {
   const { type: activeType, filter } = tabState;
   const statusParam = filter === '전체' ? '' : filter;
 
-  const { data: singleData } = useQuery({
-    ...matchQueries.SINGLE_MATCH_STATUS(statusParam),
-    enabled: activeType === '1:1',
-  });
-
-  const { data: groupData } = useQuery({
-    ...matchQueries.GROUP_MATCH_STATUS(statusParam),
-    enabled: activeType === '그룹',
-  });
-
   const handleCardClick = (card: MatchCardData) => {
     gaEvent('match_card_click', {
       match_id: card.id,
       match_type: activeType === '1:1' ? 'one_to_one' : 'group',
       match_status: card.status,
     });
-  };
-
-  const contentMap = {
-    '1:1': (
-      <MatchTabPanel
-        key="single"
-        cards={mapSingleMatchData(singleData?.results)}
-        filter={filter}
-        onCardClick={handleCardClick}
-      />
-    ),
-    그룹: (
-      <MatchTabPanel
-        key="group"
-        cards={mapGroupMatchData(groupData?.mates)}
-        filter={filter}
-        onCardClick={handleCardClick}
-      />
-    ),
   };
 
   return (
@@ -68,7 +35,14 @@ const Match = () => {
           onChange={handleFilterChange}
         />
       </nav>
-      <TabContent activeType={activeType} contentMap={contentMap} />
+
+      <MatchTabPanel
+        key={`${activeType}-${statusParam}`}
+        activeType={activeType as '1:1' | '그룹'}
+        statusParam={statusParam}
+        filter={filter}
+        onCardClick={handleCardClick}
+      />
     </div>
   );
 };

--- a/src/pages/onboarding/utils/onboarding-button.ts
+++ b/src/pages/onboarding/utils/onboarding-button.ts
@@ -79,7 +79,6 @@ export const handleButtonClick = (
     if (selections.GROUP_ROLE === '그룹원') {
       goTo?.('COMPLETE');
     } else {
-      gaEvent('match_create_click', { match_type: 'group', role: 'creator' });
       gaEvent('condition_set_completed', { match_type: 'group' });
       goNext();
     }

--- a/src/pages/sign-up/components/signup-step.tsx
+++ b/src/pages/sign-up/components/signup-step.tsx
@@ -118,7 +118,7 @@ const SignupStep = () => {
   return (
     <form
       onSubmit={handleSubmit(onSubmit)}
-      className="h-full w-full flex-col justify-between gap-[4rem] px-[1.6rem] pt-[4rem] pb-[1.6rem]"
+      className="h-svh w-full flex-col justify-between gap-[4rem] px-[1.6rem] pt-[4rem] pb-[1.6rem]"
     >
       <div className="w-full flex-col gap-[4rem]">
         <h1 className="title_24_sb whitespace-pre-line">{NICKNAME_TITLE}</h1>

--- a/src/shared/components/bottom-sheet/game-match/game-match-bottom-sheet.tsx
+++ b/src/shared/components/bottom-sheet/game-match/game-match-bottom-sheet.tsx
@@ -6,6 +6,7 @@ import GameMatchList from '@components/bottom-sheet/game-match/game-match-list';
 import { formatDateWeekday } from '@components/bottom-sheet/game-match/utils/format-date-weekday';
 import { TAB_TYPES, type TabType } from '@components/tab/tab/constants/tab-type';
 import { MATCH_REQUEST_ERROR_MESSAGES } from '@constants/error-toast';
+import { gaEvent } from '@libs/analytics';
 import { ROUTES } from '@routes/routes-config';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { AxiosError } from 'axios';
@@ -59,6 +60,12 @@ const GameMatchBottomSheet = ({
     if (selectedIdx === null) return;
     const selectedGame = gameSchedule[selectedIdx];
     if (!selectedGame) return;
+
+    const gaMatchType = activeType === TAB_TYPES.SINGLE ? 'one_to_one' : 'group';
+    gaEvent('match_create_click', {
+      match_type: gaMatchType,
+      role: 'creator',
+    });
 
     createMatchMutation.mutate(
       {


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #383 

## ☀️ New-insight
- TanStack Query 캐시가 따라오는 현상은 대부분 쿼리키 미분리, 또는 비활성 쿼리가 남아있는 상태에서 이전 캐시가 즉시 렌더되기 때문이에요. 현재 매칭 현황내에서 완료-전체-탭간 이동시 데이터가 딸려오는 현상이 발생했었어요.
- 탭/필터 전환시에는 컴포넌트 리마운트가 가장 깔끔한 포인트라고 생각했어요

## 💎 PR Point
- 이를 해결하기 위해, 쿼리 호출 위치를 이동시켰어요. 기존에응 Match.tsx에서 쿼리를 호출해 MatchTabPanel 내부로 데이터를 이동시켰었어요. 이를 MatchTabPanel 내부에서 쿼리를 실행하게 이동시켜 보이는 탭만 마운트시켜 탭의 캐시/렌더 영향을 제거시켰어요
- matchTabPanel에 key={${activeType}-${statusParam}} 부여해 탭/필터가 바뀔 때 UI/상태 초기화가 확실하게 되게 수정했어요
- 명확한 타입 보장을 위해 두 쿼리 분리를 진행했어요 (enabled)

## 📸 Screenshot

이전
<img width="372" height="762" alt="image" src="https://github.com/user-attachments/assets/050b0740-17fc-4c34-90d4-bdc9ee22f9bf" />

수정 후
<img width="320" height="561" alt="image" src="https://github.com/user-attachments/assets/4012460e-1fb7-43dd-9b8f-4035eb8d18aa" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 매치 탭이 선택한 유형/상태에 맞춰 내부적으로 데이터 로드·필터링하여 콘텐츠를 자동 갱신합니다. 카드 클릭 시 단계 진행 및 결과 화면 이동 동작은 유지됩니다.
- Style
  - 회원가입 단계 화면 높이를 동적 뷰포트 기준으로 적용해 모바일 화면 표시를 개선했습니다.
- Chores
  - 매치 생성 관련 분석 이벤트를 추가·정비하고, 불필요한 뷰 트래킹을 제거해 측정 품질을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->