### PR TITLE
fix: 회원가입 페이지, 홈 컨테이너 영역 수정

### DIFF
--- a/src/pages/home/components/top-section.tsx
+++ b/src/pages/home/components/top-section.tsx
@@ -10,7 +10,7 @@ const TopSection = () => {
   };
 
   return (
-    <section className="bg-gray-black px-[1.6rem] pt-[0.1rem]">
+    <section className="min-h-[9.6rem] bg-gray-black px-[1.6rem] pt-[0.1rem]">
       <CardBanner
         subText="나와 딱 맞는 직관 메이트를 찾고 싶다면?"
         text="이용가이드 보러 가기"

--- a/src/pages/sign-up/components/signup-step.tsx
+++ b/src/pages/sign-up/components/signup-step.tsx
@@ -118,9 +118,9 @@ const SignupStep = () => {
   return (
     <form
       onSubmit={handleSubmit(onSubmit)}
-      className="h-svh w-full flex-col justify-between gap-[4rem] px-[1.6rem] pt-[4rem] pb-[1.6rem]"
+      className="h-full w-full flex-col justify-between gap-[4rem] px-[1.6rem] pt-[4rem] pb-[1.6rem]"
     >
-      <div className="w-full flex-col gap-[4rem]">
+      <div className="h-full w-full flex-col gap-[4rem]">
         <h1 className="title_24_sb whitespace-pre-line">{NICKNAME_TITLE}</h1>
         <div className=" flex-col gap-[2.4rem]">
           <div className="flex-col gap-[0.8rem]">

--- a/src/pages/sign-up/sign-up.tsx
+++ b/src/pages/sign-up/sign-up.tsx
@@ -8,7 +8,7 @@ const SignUp = () => {
   const { Funnel, Step, goNext } = useFunnel(SIGNUP_STEPS, ROUTES.HOME);
 
   return (
-    <div className="h-fullflex-col bg-gray-white">
+    <div className="h-full flex-col bg-gray-white">
       <Funnel>
         <Step name="AGREEMENT">
           <AgreementStep next={goNext} />

--- a/src/pages/sign-up/sign-up.tsx
+++ b/src/pages/sign-up/sign-up.tsx
@@ -8,17 +8,15 @@ const SignUp = () => {
   const { Funnel, Step, goNext } = useFunnel(SIGNUP_STEPS, ROUTES.HOME);
 
   return (
-    <div className="h-full flex-col bg-gray-white">
-      <div className="flex-1">
-        <Funnel>
-          <Step name="AGREEMENT">
-            <AgreementStep next={goNext} />
-          </Step>
-          <Step name="INFORMATION">
-            <SignupStep />
-          </Step>
-        </Funnel>
-      </div>
+    <div className="h-fullflex-col bg-gray-white">
+      <Funnel>
+        <Step name="AGREEMENT">
+          <AgreementStep next={goNext} />
+        </Step>
+        <Step name="INFORMATION">
+          <SignupStep />
+        </Step>
+      </Funnel>
     </div>
   );
 };


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #388 

## ☀️ New-insight
- signup page내부에 불필요하게 존재하던 div를 없앴습니다.
- 홈 배너이미지 로딩으로 밀리는 현상이 있어서, 기본 컨테이너 영역을 지정해주었습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 스타일
  * 홈 상단 섹션에 최소 높이(9.6rem)를 적용해 상단 영역 레이아웃을 안정화했습니다.
  * 회원가입 단계 화면의 외부 컨테이너와 내부 래퍼의 높이 클래스를 조정해 세로 정렬과 스크롤 동작을 개선했습니다.

* 리팩터
  * 회원가입 페이지의 래퍼 구조에서 불필요한 중첩을 제거해 레이아웃 일관성과 렌더링 체감 성능을 향상했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->