### PR TITLE
fix: SP2 마이 페이지 및 매칭 조건 수정 페이지 수정

### DIFF
--- a/src/pages/edit-profile/edit-profile.tsx
+++ b/src/pages/edit-profile/edit-profile.tsx
@@ -2,6 +2,7 @@ import { userMutations } from '@apis/user/user-mutations';
 import { userQueries } from '@apis/user/user-queries';
 import Button from '@components/button/button/button';
 import Divider from '@components/divider/divider';
+import Icon from '@components/icon/icon';
 import Input from '@components/input/input';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { cn } from '@libs/cn';
@@ -14,7 +15,7 @@ import {
   EditProfileSchema,
   type EditProfileValues,
 } from '@pages/edit-profile/schema/EditProfileSchema';
-import { GENDER, NO_TEAM_OPTION, TEAMS } from '@pages/onboarding/constants/onboarding';
+import { NO_TEAM_OPTION, TEAMS } from '@pages/onboarding/constants/onboarding';
 import {
   INTRODUCTION_RULE_MESSAGE,
   NICKNAME_DUPLICATED,
@@ -34,9 +35,9 @@ const EditProfile = () => {
   const { data } = useQuery(userQueries.MATCH_CONDITION());
 
   const [team, setTeam] = useState<string | undefined>(undefined);
-  const [gender, setGender] = useState<string | undefined>(undefined);
   const [mateTeam, setMateTeam] = useState<string | undefined>(undefined);
   const [viewStyle, setViewStyle] = useState<string | undefined>(undefined);
+  const [avgSeason, setAvgSeason] = useState('');
   const [isSubmit, setIsSubmit] = useState(false);
   const [nicknameStatus, setNicknameStatus] = useState<NicknameStatus>('idle');
 
@@ -73,21 +74,21 @@ const EditProfile = () => {
 
   const initial = {
     team: data?.team ?? '',
-    gender: data?.genderPreference ?? '',
     mateTeam: data?.teamAllowed ?? '',
     viewStyle: data?.style ?? '',
+    avgSeason: data?.avgSeason ?? 0,
   };
 
   const teamValue = team ?? initial.team;
-  const genderValue = gender ?? initial.gender;
   const viewStyleValue = viewStyle ?? initial.viewStyle;
   const mateTeamValue = (teamValue === NO_TEAM_OPTION ? '' : (mateTeam ?? initial.mateTeam)) ?? '';
+  const avgSeasonValue = avgSeason === '' ? initial.avgSeason : Number(avgSeason);
 
   const isMatchDirty =
     teamValue !== initial.team ||
-    genderValue !== initial.gender ||
     mateTeamValue !== initial.mateTeam ||
-    viewStyleValue !== initial.viewStyle;
+    viewStyleValue !== initial.viewStyle ||
+    avgSeasonValue !== initial.avgSeason;
 
   const isSubmitDisabled = !isMatchDirty || isSubmit;
 
@@ -97,9 +98,9 @@ const EditProfile = () => {
 
     editMatchCondition({
       team: teamValue,
-      genderPreference: genderValue,
       style: viewStyleValue,
       teamAllowed: teamValue === NO_TEAM_OPTION ? null : mateTeamValue || null,
+      avgSeason: avgSeasonValue,
     });
   };
 
@@ -125,6 +126,15 @@ const EditProfile = () => {
 
       {/* 닉네임 */}
       <section>
+        <div className="mb-[2.4rem] flex-col gap-[0.8rem]">
+          <p className="body_16_m text-gray-black">프로필 이미지</p>
+          {/* TODO: 프로필 편집 api 연결 */}
+          <div className="relative w-fit">
+            <Icon name="profile" size={6.4} />
+            <Icon name="camera" size={1.6} className="absolute right-0 bottom-0" />
+          </div>
+        </div>
+
         <Controller
           name="nickname"
           control={control}
@@ -146,7 +156,7 @@ const EditProfile = () => {
             />
           )}
         />
-        <div className="mb-[2.5rem] flex justify-end gap-[0.8rem]">
+        <div className="mb-[2.4rem] flex justify-end gap-[0.8rem]">
           <Button
             type="button"
             variant={
@@ -267,12 +277,18 @@ const EditProfile = () => {
             onSelect={setViewStyle}
           />
 
-          <SelectionGroup
-            title="선호 성별"
-            options={GENDER}
-            selectedValue={genderValue}
-            onSelect={setGender}
-          />
+          <div className="flex-col gap-[1.6rem]">
+            <p className="body_16_m text-gray-black">평균 직관 수 </p>
+            <Input
+              value={avgSeason}
+              placeholder={initial.avgSeason.toString()}
+              inputMode="numeric"
+              onChange={(e) => {
+                const numericValue = e.target.value.replace(/\D/g, '').slice(0, 3);
+                setAvgSeason(numericValue);
+              }}
+            />
+          </div>
         </div>
       </section>
 

--- a/src/pages/profile/components/profile-card.tsx
+++ b/src/pages/profile/components/profile-card.tsx
@@ -1,5 +1,5 @@
 import Button from '@components/button/button/button';
-import type { ChipColor } from '@components/card/match-card/types/card';
+import { getChipColor } from '@components/card/match-card/utils/get-chip-color';
 import Chip from '@components/chip/chip';
 import Divider from '@components/divider/divider';
 import { ROUTES } from '@routes/routes-config';
@@ -12,11 +12,13 @@ interface ProfileCardProps {
   style: string;
   matchCnt?: number;
   avgSeason?: number;
-  onEditProfile?: () => void;
 }
 
 const ProfileCard = ({ nickname, imgUrl, team, style, matchCnt, avgSeason }: ProfileCardProps) => {
   const navigate = useNavigate();
+
+  const teamChipColor = getChipColor(team);
+  const styleChipColor = getChipColor(style);
 
   return (
     <div className="w-full flex-col gap-[1.2rem] rounded-[12px] bg-gray-950 p-[2rem]">
@@ -30,8 +32,8 @@ const ProfileCard = ({ nickname, imgUrl, team, style, matchCnt, avgSeason }: Pro
           <div className="flex-col gap-[0.4rem]">
             <p className="subhead_18_sb text-gray-white">{nickname}</p>
             <div className="flex gap-[0.4rem]">
-              <Chip label={team} bgColor={team as ChipColor} textColor={team as ChipColor} />
-              <Chip label={style} bgColor={style as ChipColor} textColor={style as ChipColor} />
+              <Chip label={team} bgColor={teamChipColor} textColor={teamChipColor} />
+              <Chip label={style} bgColor={styleChipColor} textColor={styleChipColor} />
             </div>
           </div>
         </div>
@@ -48,14 +50,14 @@ const ProfileCard = ({ nickname, imgUrl, team, style, matchCnt, avgSeason }: Pro
       <div className="w-full flex-row-evenly rounded-[8px] bg-gray-700 px-[1.2rem] py-[0.8rem]">
         <div className="flex-col-between gap-[0.2rem]">
           <p className="cap_14_sb text-gray-400">함께한 매칭</p>
-          <p className="head_20_sb text-gray-white">{matchCnt}</p>
+          <p className="head_20_sb text-gray-white">{matchCnt ?? '-'}</p>
         </div>
         <div className="h-[3.3rem]">
           <Divider direction="vertical" thickness={0.1} color="bg-gray-600" />
         </div>
         <div className="flex-col-between gap-[0.2rem]">
           <p className="cap_14_sb text-gray-400">시즌 평균 직관</p>
-          <p className="head_20_sb text-gray-white">{avgSeason}</p>
+          <p className="head_20_sb text-gray-white">{avgSeason ?? '-'}</p>
         </div>
       </div>
     </div>

--- a/src/pages/profile/components/profile-card.tsx
+++ b/src/pages/profile/components/profile-card.tsx
@@ -1,0 +1,65 @@
+import Button from '@components/button/button/button';
+import type { ChipColor } from '@components/card/match-card/types/card';
+import Chip from '@components/chip/chip';
+import Divider from '@components/divider/divider';
+import { ROUTES } from '@routes/routes-config';
+import { useNavigate } from 'react-router-dom';
+
+interface ProfileCardProps {
+  nickname: string;
+  imgUrl: string;
+  team: string;
+  style: string;
+  matchCnt?: number;
+  avgSeason?: number;
+  onEditProfile?: () => void;
+}
+
+const ProfileCard = ({ nickname, imgUrl, team, style, matchCnt, avgSeason }: ProfileCardProps) => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="w-full flex-col gap-[1.2rem] rounded-[12px] bg-gray-950 p-[2rem]">
+      <div className="flex-row-between">
+        <div className="flex gap-[0.8rem]">
+          <img
+            src={imgUrl}
+            alt={`${nickname} 프로필 이미지`}
+            className="h-[6rem] w-[6rem] rounded-[60px]"
+          />
+          <div className="flex-col gap-[0.4rem]">
+            <p className="subhead_18_sb text-gray-white">{nickname}</p>
+            <div className="flex gap-[0.4rem]">
+              <Chip label={team} bgColor={team as ChipColor} textColor={team as ChipColor} />
+              <Chip label={style} bgColor={style as ChipColor} textColor={style as ChipColor} />
+            </div>
+          </div>
+        </div>
+        <div>
+          <Button
+            size="S"
+            label="프로필 수정"
+            className="cap_14_sb rounded-[8px]"
+            onClick={() => navigate(ROUTES.PROFILE_EDIT)}
+          />
+        </div>
+      </div>
+
+      <div className="w-full flex-row-evenly rounded-[8px] bg-gray-700 px-[1.2rem] py-[0.8rem]">
+        <div className="flex-col-between gap-[0.2rem]">
+          <p className="cap_14_sb text-gray-400">함께한 매칭</p>
+          <p className="head_20_sb text-gray-white">{matchCnt}</p>
+        </div>
+        <div className="h-[3.3rem]">
+          <Divider direction="vertical" thickness={0.1} color="bg-gray-600" />
+        </div>
+        <div className="flex-col-between gap-[0.2rem]">
+          <p className="cap_14_sb text-gray-400">시즌 평균 직관</p>
+          <p className="head_20_sb text-gray-white">{avgSeason}</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProfileCard;

--- a/src/pages/profile/components/profile-card.tsx
+++ b/src/pages/profile/components/profile-card.tsx
@@ -12,6 +12,7 @@ interface ProfileCardProps {
   style: string;
   matchCnt?: number;
   avgSeason?: number;
+  onEditProfile?: () => void;
 }
 
 const ProfileCard = ({ nickname, imgUrl, team, style, matchCnt, avgSeason }: ProfileCardProps) => {

--- a/src/pages/profile/profile.tsx
+++ b/src/pages/profile/profile.tsx
@@ -1,14 +1,17 @@
 import { userMutations } from '@apis/user/user-mutations';
 import { userQueries } from '@apis/user/user-queries';
 import Button from '@components/button/button/button';
-import Card from '@components/card/match-card/card';
-import type { ChipColor } from '@components/chip/chip-list';
 import Divider from '@components/divider/divider';
 import Footer from '@components/footer/footer';
 import { FEEDBACK_LINK, REQUEST_LINK } from '@pages/profile/constants/link';
 import { ROUTES } from '@routes/routes-config';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
+import ProfileCard from './components/profile-card';
+
+// TODO: api 연결
+const MOCK_MATCH_COUNT = 1;
+const MOCK_AVERAGE_SEASON_COUNT = 3;
 
 const Profile = () => {
   const navigate = useNavigate();
@@ -21,17 +24,14 @@ const Profile = () => {
   return (
     <div className="h-full flex-col-between">
       <div className="w-full flex-col-center gap-[1.6rem] px-[1.6rem] pt-[1.6rem] pb-[5.6rem]">
-        <Card
-          className="!shadow-none"
-          type="user"
+        <ProfileCard
           nickname={data.nickname ?? ''}
-          imgUrl={[data.imgUrl ?? '']}
+          imgUrl={data.imgUrl ?? ''}
           team={data.team ?? ''}
           style={data.style ?? ''}
-          age={data.age ?? ''}
-          gender={data.gender ?? ''}
-          introduction={data.introduction ?? ''}
-          chips={[(data.team ?? '') as ChipColor, (data.style ?? '') as ChipColor]}
+          matchCnt={MOCK_MATCH_COUNT}
+          avgSeason={MOCK_AVERAGE_SEASON_COUNT}
+          onEditProfile={() => navigate(ROUTES.PROFILE_EDIT)}
         />
         <Button
           size="L"

--- a/src/pages/profile/profile.tsx
+++ b/src/pages/profile/profile.tsx
@@ -1,6 +1,5 @@
 import { userMutations } from '@apis/user/user-mutations';
 import { userQueries } from '@apis/user/user-queries';
-import Button from '@components/button/button/button';
 import Divider from '@components/divider/divider';
 import Footer from '@components/footer/footer';
 import { FEEDBACK_LINK, REQUEST_LINK } from '@pages/profile/constants/link';
@@ -23,7 +22,7 @@ const Profile = () => {
 
   return (
     <div className="h-full flex-col-between">
-      <div className="w-full flex-col-center gap-[1.6rem] px-[1.6rem] pt-[1.6rem] pb-[5.6rem]">
+      <div className="w-full flex-col-center gap-[3.2rem] px-[1.6rem] pt-[1.6rem] pb-[5.6rem]">
         <ProfileCard
           nickname={data.nickname ?? ''}
           imgUrl={data.imgUrl ?? ''}
@@ -33,12 +32,6 @@ const Profile = () => {
           avgSeason={MOCK_AVERAGE_SEASON_COUNT}
           onEditProfile={() => navigate(ROUTES.PROFILE_EDIT)}
         />
-        <Button
-          size="L"
-          label="프로필 · 매칭 조건 수정"
-          onClick={() => navigate(ROUTES.PROFILE_EDIT)}
-        />
-        <Divider thickness={0.4} color="bg-gray-200" />
         <section className="w-full flex-col items-start">
           <a
             href={REQUEST_LINK}

--- a/src/pages/profile/profile.tsx
+++ b/src/pages/profile/profile.tsx
@@ -8,10 +8,6 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import ProfileCard from './components/profile-card';
 
-// TODO: api 연결
-const MOCK_MATCH_COUNT = 1;
-const MOCK_AVERAGE_SEASON_COUNT = 3;
-
 const Profile = () => {
   const navigate = useNavigate();
 
@@ -25,11 +21,11 @@ const Profile = () => {
       <div className="w-full flex-col-center gap-[3.2rem] px-[1.6rem] pt-[1.6rem] pb-[5.6rem]">
         <ProfileCard
           nickname={data.nickname ?? ''}
-          imgUrl={data.imgUrl ?? ''}
           team={data.team ?? ''}
           style={data.style ?? ''}
-          matchCnt={MOCK_MATCH_COUNT}
-          avgSeason={MOCK_AVERAGE_SEASON_COUNT}
+          imgUrl={data.imgUrl ?? ''}
+          matchCnt={data.matchCnt ?? 0}
+          avgSeason={data.avgSeason ?? 0}
           onEditProfile={() => navigate(ROUTES.PROFILE_EDIT)}
         />
         <section className="w-full flex-col items-start">

--- a/src/shared/apis/user/user-mutations.ts
+++ b/src/shared/apis/user/user-mutations.ts
@@ -62,8 +62,8 @@ export const userMutations = {
   EDIT_MATCH_CONDITION: () =>
     mutationOptions<postMatchConditionRequest, Error, postMatchConditionRequest>({
       mutationKey: USER_KEY.MATCH_CONDITION(),
-      mutationFn: ({ team, teamAllowed, style, genderPreference }) =>
-        patch(END_POINT.MATCH_CONDITION, { team, teamAllowed, style, genderPreference }),
+      mutationFn: ({ team, teamAllowed, style, avgSeason }) =>
+        patch(END_POINT.MATCH_CONDITION, { team, teamAllowed, style, avgSeason }),
     }),
 
   AGREEMENT_INFO: () =>

--- a/src/shared/components/button/button/styles/button-variants.ts
+++ b/src/shared/components/button/button/styles/button-variants.ts
@@ -14,6 +14,7 @@ export const buttonVariants = cva(
         disabled: 'rounded-[0.8rem] bg-gray-100 text-gray-400',
       },
       size: {
+        S: 'w-full px-[1.6rem] py-[0.6rem]',
         M: 'w-full px-[0.8rem] py-[1.2rem]',
         L: 'w-full px-[0.8rem] py-[1.2rem]',
         setting_M: 'w-full p-[0.8rem]',

--- a/src/shared/components/card/match-card/types/card.ts
+++ b/src/shared/components/card/match-card/types/card.ts
@@ -1,11 +1,25 @@
 import type { cardVariants } from '@components/card/match-card/styles/card-variants';
 import type { chipStateVariants } from '@components/chip/styles/chip-state-variants';
-import type { chipVariants } from '@components/chip/styles/chip-variants';
 import type { VariantProps } from 'class-variance-authority';
 
 export type ChipColorType = NonNullable<VariantProps<typeof chipStateVariants>['colorType']>;
 type ColorType = NonNullable<VariantProps<typeof cardVariants>['color']>;
-export type ChipColor = NonNullable<VariantProps<typeof chipVariants>['bgColor']>;
+
+export type ChipColor =
+  | '두산'
+  | 'LG'
+  | '롯데'
+  | 'NC'
+  | 'KIA'
+  | '한화'
+  | 'KT'
+  | '삼성'
+  | 'SSG'
+  | '키움'
+  | '열정응원러'
+  | '경기집중러'
+  | '직관먹방러'
+  | 'default';
 
 export interface BaseCardProps {
   id: number;

--- a/src/shared/components/card/match-card/utils/get-chip-color.ts
+++ b/src/shared/components/card/match-card/utils/get-chip-color.ts
@@ -1,0 +1,23 @@
+import type { ChipColor } from '@components/card/match-card/types/card';
+
+const CHIP_COLOR_MAP: Record<string, ChipColor> = {
+  두산: '두산',
+  LG: 'LG',
+  롯데: '롯데',
+  NC: 'NC',
+  KIA: 'KIA',
+  한화: '한화',
+  KT: 'KT',
+  삼성: '삼성',
+  SSG: 'SSG',
+  키움: '키움',
+  열정응원러: '열정응원러',
+  경기집중러: '경기집중러',
+  직관먹방러: '직관먹방러',
+};
+
+export const getChipColor = (value: string | null | undefined): ChipColor => {
+  if (!value) return 'default';
+
+  return CHIP_COLOR_MAP[value] ?? 'default';
+};

--- a/src/shared/components/chip/styles/chip-state-variants.ts
+++ b/src/shared/components/chip/styles/chip-state-variants.ts
@@ -8,7 +8,7 @@ export const chipStateVariants = cva(
         active: 'bg-main-900 text-gray-white',
         inactive: 'bg-gray-200 text-gray-700',
         dark: 'bg-gray-800 text-gray-white',
-        outline: 'bg-gray-white text-main-900 outline outline-[1px] outline-main-900',
+        outline: 'bg-gray-white text-main-900 outline-[1px] outline-main-900',
       },
     },
     defaultVariants: {

--- a/src/shared/components/chip/styles/chip-state-variants.ts
+++ b/src/shared/components/chip/styles/chip-state-variants.ts
@@ -8,7 +8,7 @@ export const chipStateVariants = cva(
         active: 'bg-main-900 text-gray-white',
         inactive: 'bg-gray-200 text-gray-700',
         dark: 'bg-gray-800 text-gray-white',
-        outline: 'bg-gray-white text-main-900 outline-[1px] outline-main-900',
+        outline: 'bg-gray-white text-main-900 outline outline-[1px] outline-main-900',
       },
     },
     defaultVariants: {

--- a/src/shared/constants/api.ts
+++ b/src/shared/constants/api.ts
@@ -17,7 +17,7 @@ export const END_POINT = {
   GET_USER_INFO: '/v1/users/info',
   POST_INFO_NICKNAME: '/v1/users/info/nickname',
   POST_EDIT_PROFILE: '/v2/users/info',
-  MATCH_CONDITION: '/v2/users/match-condition',
+  MATCH_CONDITION: '/v3/users/match-condition',
 
   // 경기 관련
   GET_GAME_SCHEDULE: (date: string) => `/v1/users/game/schedule?date=${date}`,

--- a/src/shared/constants/api.ts
+++ b/src/shared/constants/api.ts
@@ -14,7 +14,7 @@ export const END_POINT = {
   USER_INFO: '/v2/users/info',
   GET_NICKNAME_CHECK: (nickname: string) =>
     `/v2/users/info?nickname=${encodeURIComponent(nickname)}`,
-  GET_USER_INFO: '/v1/users/info',
+  GET_USER_INFO: '/v3/users/info',
   POST_INFO_NICKNAME: '/v1/users/info/nickname',
   POST_EDIT_PROFILE: '/v2/users/info',
   MATCH_CONDITION: '/v3/users/match-condition',

--- a/src/shared/styles/custom-utilities.css
+++ b/src/shared/styles/custom-utilities.css
@@ -12,6 +12,10 @@
     @apply flex flex-row justify-between items-center;
   }
 
+  .flex-row-evenly {
+    @apply flex flex-row justify-evenly items-center;
+  }
+
   .flex-row-end {
     @apply flex flex-row justify-end items-center;
   }

--- a/src/shared/styles/theme.css
+++ b/src/shared/styles/theme.css
@@ -31,6 +31,7 @@
 
   /* Grayscale */
   --color-gray-black: #1a1a1a;
+  --color-gray-950: #333333;
   --color-gray-900: #3a3a3b;
   --color-gray-800: #464748;
   --color-gray-700: #656667;

--- a/src/shared/types/user-types.ts
+++ b/src/shared/types/user-types.ts
@@ -61,7 +61,7 @@ export interface getMatchConditionResponse {
   team: string;
   teamAllowed: string | null;
   style: string;
-  genderPreference: string;
+  avgSeason: number;
 }
 
 /**
@@ -73,5 +73,5 @@ export interface postMatchConditionRequest {
   team: string;
   teamAllowed: string | null;
   style: string;
-  genderPreference: string;
+  avgSeason: number;
 }

--- a/src/shared/types/user-types.ts
+++ b/src/shared/types/user-types.ts
@@ -3,16 +3,15 @@ import type { ApiResponse } from './base-types';
 /**
  * 유저 정보 조회 응답
  * get
- * /v1/users/info
+ * /v3/users/info
  */
 export interface getUserInfoResponse {
   nickname: string | null;
-  age: string | null;
-  gender: string | null;
   team: string | null;
   style: string | null;
-  introduction: string | null;
   imgUrl: string | null;
+  matchCnt: number | null;
+  avgSeason: number | null;
 }
 
 /**

--- a/src/stories/foundations/tokens/colors.ts
+++ b/src/stories/foundations/tokens/colors.ts
@@ -32,6 +32,7 @@ export const ETC_COLORS = {
 
 export const GRAYSCALE_COLORS = {
   'gray-black': '#1a1a1a',
+  'gray-950': '#333333',
   'gray-900': '#3a3a3b',
   'gray-800': '#464748',
   'gray-700': '#656667',


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #399 

## ☀️ New-insight

- 숫자 입력 처리 시 `number` state보다 `string` state로 관리한 뒤 변환하는 것이 UX 및 validation 처리에 더 유리하다

## 💎 PR Point

- 기존 Card 컴포넌트를 확장하지 않고, ProfileCard를 별도 컴포넌트로 분리
- 매칭 조건 수정 페이지에서 성별 섹션 삭제, 평균 직관 수 섹션 추가
- 매칭 수, 평균 직관 수 api 연결 완료
- 매칭 조건 수정(평균 직관 수) api 연결 완료
- 프로필 이미지 api는 머지 후 회원가입 페이지와 한번에 연결 예정

## 📸 Screenshot

<table>
<tr> <th><img width="390" height="685" alt="스크린샷 2026-03-24 오전 1 32 03" src="https://github.com/user-attachments/assets/53d05dbf-5582-4d8d-be6c-9eaae9c33b99" /></th> <th><img width="390" height="685" alt="스크린샷 2026-03-24 오전 1 32 28" src="https://github.com/user-attachments/assets/19342533-6e9a-4158-be7e-86a9ee79806b" /></th> <th><img width="390" height="685" alt="스크린샷 2026-03-24 오전 1 39 58" src="https://github.com/user-attachments/assets/0a3dea4b-0514-48fa-a06c-1bd0269cb864" /></th>
</table>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 프로필 카드에 매칭 횟수 및 평균 시즌 통계 표시 추가
  * 프로필 편집 페이지에 프로필 이미지 섹션 추가

* **Refactor**
  * 매칭 조건에서 성별 선호도를 평균 직관 수로 변경
  * 매칭 조건 API 엔드포인트 및 요청 구조 업데이트

* **Style**
  * 새로운 버튼 크기 및 색상 토큰 추가
  * UI 레이아웃 및 스타일 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->