### PR TITLE
fix: SP2 온보딩 화면 관련 수정

### DIFF
--- a/src/pages/game/game.tsx
+++ b/src/pages/game/game.tsx
@@ -120,7 +120,7 @@ const Game = () => {
   }, [gameMatchData, setHeaderTitle]);
 
   return (
-    <div className="relative h-full flex-col gap-[1.2rem] px-[1.6rem] pt-[2rem]">
+    <div className="relative h-full flex-col gap-[1.2rem] bg-gray-100 px-[1.6rem] pt-[2rem]">
       {gameMatchData?.result?.map((match) => (
         // TODO: 매칭 현황 상태가 [그룹원 모집중]인 카드만 노출
         <button

--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -5,6 +5,7 @@ import Button from '@components/button/button/button';
 import { WEEK_CALENDAR_START_OFFSET } from '@components/calendar/constants/CALENDAR';
 import Dialog from '@components/dialog/dialog';
 import { TAB_TYPES, type TabType } from '@components/tab/tab/constants/tab-type';
+import { CREATE_MATCH_TOAST_MESSAGE } from '@constants/error-toast';
 import useAuth from '@hooks/use-auth';
 import { useTabState } from '@hooks/use-tab-state';
 import { gaEvent } from '@libs/analytics';
@@ -19,8 +20,9 @@ import { ROUTES } from '@routes/routes-config';
 import { useMutation } from '@tanstack/react-query';
 import { addDays, format } from 'date-fns';
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { handleScrollLock } from '@/shared/utils/scroll-lock';
+import { showErrorToast } from '@/shared/utils/show-error-toast';
 
 // TODO: 선택 날짜 유지 로직 수정
 // const getSelectedDateFromQuery = (searchParams: URLSearchParams, fallbackDate: Date): Date => {
@@ -32,6 +34,7 @@ import { handleScrollLock } from '@/shared/utils/scroll-lock';
 
 const Home = () => {
   const { activeType, changeTab } = useTabState();
+  const location = useLocation();
   const navigate = useNavigate();
   // const [searchParams, setSearchParams] = useSearchParams();
   const entryDate = new Date();
@@ -67,6 +70,21 @@ const Home = () => {
     const from = needsMatchingSetup ? 'onboarding' : 'return_user';
     gaEvent('home_enter', { from });
   }, [needsMatchingSetup]);
+
+  useEffect(() => {
+    if (location.state?.shouldShowMatchCreatedToast) {
+      showErrorToast(CREATE_MATCH_TOAST_MESSAGE, {
+        offset: '8.8rem',
+        icon: false,
+        className: 'bg-sub-900 text-gray-black cap_14_sb',
+      });
+
+      navigate(location.pathname, {
+        replace: true,
+        state: {},
+      });
+    }
+  }, [location, navigate]);
 
   // const syncSelectedDateToQuery = (date: Date) => {
   //   const nextParams = new URLSearchParams(searchParams);

--- a/src/pages/onboarding/components/complete-button-section.tsx
+++ b/src/pages/onboarding/components/complete-button-section.tsx
@@ -1,12 +1,59 @@
+import { matchMutations } from '@apis/match/match-mutations';
+import { matchQueries } from '@apis/match/match-queries';
 import Button from '@components/button/button/button';
+import { gaEvent } from '@libs/analytics';
 import { ROUTES } from '@routes/routes-config';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
+import type { SelectedGame } from './date-select';
 
-const CompleteButtonSection = () => {
+interface CompleteButtonSectionProps {
+  pendingMatch: {
+    game: SelectedGame;
+    date: string;
+    type: 'single' | 'group';
+  };
+}
+
+const CompleteButtonSection = ({ pendingMatch }: CompleteButtonSectionProps) => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const createMatchMutation = useMutation(matchMutations.CREATE_MATCH());
 
   const handleGoToMate = () => {
     navigate(ROUTES.HOME);
+  };
+
+  const handleCreate = () => {
+    const matchType = pendingMatch.type === 'single' ? 'DIRECT' : 'GROUP';
+    const gaMatchType = pendingMatch.type === 'single' ? 'one_to_one' : 'group';
+
+    gaEvent('match_create_click', {
+      match_type: gaMatchType,
+      role: 'creator',
+    });
+
+    createMatchMutation.mutate(
+      {
+        gameId: pendingMatch.game.id,
+        matchType,
+      },
+      {
+        onSuccess: () => {
+          if (matchType === 'DIRECT') {
+            queryClient.invalidateQueries({
+              queryKey: matchQueries.SINGLE_MATCH_LIST(pendingMatch.date).queryKey,
+            });
+          } else {
+            queryClient.invalidateQueries({
+              queryKey: matchQueries.GROUP_MATCH_LIST(pendingMatch.date).queryKey,
+            });
+          }
+
+          navigate(ROUTES.HOME);
+        },
+      },
+    );
   };
 
   return (
@@ -19,13 +66,7 @@ const CompleteButtonSection = () => {
           className="w-full"
           onClick={handleGoToMate}
         />
-        <Button
-          label="만들기"
-          size="M"
-          variant="blue"
-          className="w-full"
-          onClick={handleGoToMate}
-        />
+        <Button label="만들기" size="M" variant="blue" className="w-full" onClick={handleCreate} />
       </section>
     </div>
   );

--- a/src/pages/onboarding/components/complete-button-section.tsx
+++ b/src/pages/onboarding/components/complete-button-section.tsx
@@ -25,6 +25,8 @@ const CompleteButtonSection = ({ pendingMatch }: CompleteButtonSectionProps) => 
   };
 
   const handleCreate = () => {
+    if (createMatchMutation.isPending) return;
+
     const matchType = pendingMatch.type === 'single' ? 'DIRECT' : 'GROUP';
     const gaMatchType = pendingMatch.type === 'single' ? 'one_to_one' : 'group';
 
@@ -70,7 +72,14 @@ const CompleteButtonSection = ({ pendingMatch }: CompleteButtonSectionProps) => 
           className="w-full"
           onClick={handleGoToMate}
         />
-        <Button label="만들기" size="M" variant="blue" className="w-full" onClick={handleCreate} />
+        <Button
+          label="만들기"
+          size="M"
+          variant="blue"
+          className="w-full"
+          onClick={handleCreate}
+          disabled={createMatchMutation.isPending}
+        />
       </section>
     </div>
   );

--- a/src/pages/onboarding/components/complete-button-section.tsx
+++ b/src/pages/onboarding/components/complete-button-section.tsx
@@ -50,7 +50,11 @@ const CompleteButtonSection = ({ pendingMatch }: CompleteButtonSectionProps) => 
             });
           }
 
-          navigate(ROUTES.HOME);
+          navigate(ROUTES.HOME, {
+            state: {
+              shouldShowMatchCreatedToast: true,
+            },
+          });
         },
       },
     );

--- a/src/pages/onboarding/components/complete-group-card.tsx
+++ b/src/pages/onboarding/components/complete-group-card.tsx
@@ -7,12 +7,20 @@ const CompleteGroupCard = ({ matchId }: { matchId: number }) => {
   const { data } = useSuspenseQuery(matchQueries.GROUP_MATCH_RESULT(matchId));
 
   const cardProps: CardProps = {
-    ...data,
-    type: 'group',
+    id: data.id,
+    type: 'game',
+    nickname: data.nickname,
+    count: data.count,
+    imgUrl: Array.isArray(data.imgUrl) ? data.imgUrl : [data.imgUrl],
+    awayTeam: data.awayTeam,
+    homeTeam: data.homeTeam,
+    stadium: data.stadium,
+    date: data.date,
+    isGroup: true,
     className: 'w-full',
   };
 
-  return <Card isCreated {...cardProps} />;
+  return <Card {...cardProps} />;
 };
 
 export default CompleteGroupCard;

--- a/src/pages/onboarding/components/complete-single-card.tsx
+++ b/src/pages/onboarding/components/complete-single-card.tsx
@@ -1,20 +1,26 @@
 import { matchQueries } from '@apis/match/match-queries';
 import Card from '@components/card/match-card/card';
-import type { CardProps, ChipColor } from '@components/card/match-card/types/card';
+import type { CardProps } from '@components/card/match-card/types/card';
 import { useSuspenseQuery } from '@tanstack/react-query';
 
 const CompleteSingleCard = ({ matchId }: { matchId: number }) => {
   const { data } = useSuspenseQuery(matchQueries.SINGLE_MATCH_RESULT(matchId));
 
   const cardProps: CardProps = {
-    ...data,
-    type: 'single',
+    id: data.id,
+    type: 'game',
+    nickname: data.nickname,
+    count: 1,
     imgUrl: [data.imgUrl],
-    chips: [data.team, data.style] as ChipColor[],
+    awayTeam: data.awayTeam,
+    homeTeam: data.homeTeam,
+    stadium: data.stadium,
+    date: data.date,
+    isGroup: false,
     className: 'w-full',
   };
 
-  return <Card isCreated {...cardProps} />;
+  return <Card {...cardProps} />;
 };
 
 export default CompleteSingleCard;

--- a/src/pages/onboarding/components/complete.tsx
+++ b/src/pages/onboarding/components/complete.tsx
@@ -1,14 +1,22 @@
+import { userQueries } from '@apis/user/user-queries';
 import { MATCHING_SUGGESTION_MESSAGE_TITLE } from '@pages/match/constants/matching';
+import { useQuery } from '@tanstack/react-query';
 import CompleteGroupCard from './complete-group-card';
 import CompleteSingleCard from './complete-single-card';
 
 interface CompleteProps {
-  nickname: string;
   matchId: number;
   type?: 'single' | 'group';
 }
 
-const Complete = ({ nickname, matchId, type }: CompleteProps) => {
+const Complete = ({ matchId, type }: CompleteProps) => {
+  const { data } = useQuery({
+    ...userQueries.USER_INFO(),
+    enabled: true,
+  });
+
+  const nickname = data?.nickname ?? '사용자';
+
   return (
     <div className="w-full flex-1 flex-col-between gap-[4rem] whitespace-pre-line pt-[6.45rem]">
       <div className="w-full flex-col gap-[4rem] px-[1.6rem]">

--- a/src/pages/onboarding/components/complete.tsx
+++ b/src/pages/onboarding/components/complete.tsx
@@ -1,21 +1,38 @@
 import { userQueries } from '@apis/user/user-queries';
+import Card from '@components/card/match-card/card';
+import type { CardProps } from '@components/card/match-card/types/card';
 import { MATCHING_SUGGESTION_MESSAGE_TITLE } from '@pages/match/constants/matching';
 import { useQuery } from '@tanstack/react-query';
-import CompleteGroupCard from './complete-group-card';
-import CompleteSingleCard from './complete-single-card';
+import type { SelectedGame } from './date-select';
 
 interface CompleteProps {
-  matchId: number;
+  selectedGame: SelectedGame;
+  selectedDate: string;
   type?: 'single' | 'group';
 }
 
-const Complete = ({ matchId, type }: CompleteProps) => {
+const Complete = ({ selectedGame, selectedDate, type }: CompleteProps) => {
   const { data } = useQuery({
     ...userQueries.USER_INFO(),
     enabled: true,
   });
 
   const nickname = data?.nickname ?? '사용자';
+  const imgUrl = data?.imgUrl ?? '';
+
+  const cardProps: CardProps = {
+    id: selectedGame.id,
+    type: 'game',
+    nickname,
+    count: 1,
+    imgUrl: imgUrl ? [imgUrl] : [],
+    awayTeam: selectedGame.awayTeam,
+    homeTeam: selectedGame.homeTeam,
+    stadium: selectedGame.stadium,
+    date: selectedDate,
+    isGroup: type === 'group',
+    className: 'w-full',
+  };
 
   return (
     <div className="w-full flex-1 flex-col-between gap-[4rem] whitespace-pre-line pt-[6.45rem]">
@@ -24,11 +41,7 @@ const Complete = ({ matchId, type }: CompleteProps) => {
           {MATCHING_SUGGESTION_MESSAGE_TITLE(nickname)}
         </p>
 
-        {type === 'single' ? (
-          <CompleteSingleCard matchId={matchId} />
-        ) : (
-          <CompleteGroupCard matchId={matchId} />
-        )}
+        <Card {...cardProps} />
       </div>
     </div>
   );

--- a/src/pages/onboarding/components/date-select.tsx
+++ b/src/pages/onboarding/components/date-select.tsx
@@ -11,8 +11,16 @@ import { format } from 'date-fns';
 import { useState } from 'react';
 import { showErrorToast } from '@/shared/utils/show-error-toast';
 
+export interface SelectedGame {
+  id: number;
+  awayTeam: string;
+  homeTeam: string;
+  gameTime: string;
+  stadium: string;
+}
+
 interface DateSelectProps {
-  onComplete: (matchId: number) => void;
+  onComplete: (selected: { game: SelectedGame; date: string }) => void;
   activeType: TabType;
 }
 
@@ -71,7 +79,7 @@ const DateSelect = ({ onComplete, activeType }: DateSelectProps) => {
         date={format(selectedDate ?? new Date(), 'yyyy-MM-dd')}
         gameSchedule={data ?? []}
         activeType={activeType}
-        fromOnboarding={true}
+        fromOnboarding
         onComplete={onComplete}
       />
     </div>

--- a/src/pages/onboarding/onboarding.tsx
+++ b/src/pages/onboarding/onboarding.tsx
@@ -4,7 +4,7 @@ import { TAB_TYPES } from '@components/tab/tab/constants/tab-type';
 import { useFunnel } from '@hooks/use-funnel';
 import Complete from '@pages/onboarding/components/complete';
 import CompleteButtonSection from '@pages/onboarding/components/complete-button-section';
-import DateSelect from '@pages/onboarding/components/date-select';
+import DateSelect, { type SelectedGame } from '@pages/onboarding/components/date-select';
 import Frequency from '@pages/onboarding/components/frequency';
 import MatchingType from '@pages/onboarding/components/matching-type';
 import OnboardingHeader from '@pages/onboarding/components/onboarding-header';
@@ -33,8 +33,9 @@ const Onboarding = () => {
     MATCHING_TYPE: null,
   });
 
-  const [createdMatch, setCreatedMatch] = useState<{
-    matchId: number;
+  const [pendingMatch, setPendingMatch] = useState<{
+    game: SelectedGame;
+    date: string;
     type: 'single' | 'group';
   } | null>(null);
 
@@ -43,7 +44,6 @@ const Onboarding = () => {
   };
 
   const navigate = useNavigate();
-
   const { mutate } = useMutation(matchMutations.MATCH_CONDITION());
 
   const handlePrev = () => {
@@ -112,9 +112,10 @@ const Onboarding = () => {
               activeType={
                 selections.MATCHING_TYPE === '1:1 매칭' ? TAB_TYPES.SINGLE : TAB_TYPES.GROUP
               }
-              onComplete={(matchId) => {
-                setCreatedMatch({
-                  matchId,
+              onComplete={({ game, date }) => {
+                setPendingMatch({
+                  game,
+                  date,
                   type: selections.MATCHING_TYPE === '1:1 매칭' ? 'single' : 'group',
                 });
                 goNext();
@@ -123,7 +124,13 @@ const Onboarding = () => {
           </Step>
 
           <Step name="COMPLETE">
-            {createdMatch && <Complete matchId={createdMatch.matchId} type={createdMatch.type} />}
+            {pendingMatch && (
+              <Complete
+                selectedGame={pendingMatch.game}
+                selectedDate={pendingMatch.date}
+                type={pendingMatch.type}
+              />
+            )}
           </Step>
         </Funnel>
 
@@ -146,7 +153,9 @@ const Onboarding = () => {
             />
           </div>
         )}
-        {currentStep === 'COMPLETE' && <CompleteButtonSection />}
+        {currentStep === 'COMPLETE' && pendingMatch && (
+          <CompleteButtonSection pendingMatch={pendingMatch} />
+        )}
       </div>
     </div>
   );

--- a/src/pages/onboarding/onboarding.tsx
+++ b/src/pages/onboarding/onboarding.tsx
@@ -60,7 +60,7 @@ const Onboarding = () => {
   };
 
   return (
-    <div className="h-full flex-col">
+    <div className="h-full flex-col bg-background">
       <div className="sticky top-0 bg-background">
         <OnboardingHeader onClick={handlePrev} />
         {currentStep !== 'COMPLETE' && (

--- a/src/pages/onboarding/onboarding.tsx
+++ b/src/pages/onboarding/onboarding.tsx
@@ -1,5 +1,4 @@
 import { matchMutations } from '@apis/match/match-mutations';
-import { userQueries } from '@apis/user/user-queries';
 import Button from '@components/button/button/button';
 import { TAB_TYPES } from '@components/tab/tab/constants/tab-type';
 import { useFunnel } from '@hooks/use-funnel';
@@ -16,7 +15,7 @@ import ViewingStyle from '@pages/onboarding/components/viewing-style';
 import { FIRST_FUNNEL_STEPS, NO_TEAM_OPTION } from '@pages/onboarding/constants/onboarding';
 import { handleButtonClick, isButtonDisabled } from '@pages/onboarding/utils/onboarding-button';
 import { ROUTES } from '@routes/routes-config';
-import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -60,9 +59,6 @@ const Onboarding = () => {
     }
   };
 
-  const { data: user } = useSuspenseQuery(userQueries.USER_INFO());
-  const nickname = user.nickname;
-
   return (
     <div className="h-full flex-col">
       <div className="sticky top-0 bg-background">
@@ -104,14 +100,6 @@ const Onboarding = () => {
             />
           </Step>
 
-          {/* TODO: GENDER 단계 관련 전부 삭제 */}
-          {/* <Step name="GENDER">
-            <Gender
-              selectedOption={selections.GENDER}
-              onSelect={(option) => handleSelect('GENDER', option)}
-            />
-          </Step> */}
-
           <Step name="MATCHING_TYPE">
             <MatchingType
               selectedOption={selections.MATCHING_TYPE}
@@ -135,13 +123,7 @@ const Onboarding = () => {
           </Step>
 
           <Step name="COMPLETE">
-            {createdMatch && (
-              <Complete
-                nickname={nickname ?? ''}
-                matchId={createdMatch.matchId}
-                type={createdMatch.type}
-              />
-            )}
+            {createdMatch && <Complete matchId={createdMatch.matchId} type={createdMatch.type} />}
           </Step>
         </Funnel>
 

--- a/src/shared/components/bottom-sheet/game-match/game-match-bottom-sheet.tsx
+++ b/src/shared/components/bottom-sheet/game-match/game-match-bottom-sheet.tsx
@@ -5,32 +5,22 @@ import GameMatchFooter from '@components/bottom-sheet/game-match/game-match-foot
 import GameMatchList from '@components/bottom-sheet/game-match/game-match-list';
 import { formatDateWeekday } from '@components/bottom-sheet/game-match/utils/format-date-weekday';
 import { TAB_TYPES, type TabType } from '@components/tab/tab/constants/tab-type';
-import { MATCH_REQUEST_ERROR_MESSAGES } from '@constants/error-toast';
 import { gaEvent } from '@libs/analytics';
+import type { SelectedGame } from '@pages/onboarding/components/date-select';
 import { ROUTES } from '@routes/routes-config';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import type { AxiosError } from 'axios';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { showErrorToast } from '@/shared/utils/show-error-toast';
-
-interface GameScheduleItem {
-  id: number;
-  awayTeam: string;
-  homeTeam: string;
-  gameTime: string;
-  stadium: string;
-}
 
 interface GameMatchBottomSheetProps {
   isOpen: boolean;
   onClose: () => void;
   date: string;
-  gameSchedule: GameScheduleItem[];
+  gameSchedule: SelectedGame[];
   onClick?: (selectedId: number | null) => void;
   activeType: TabType;
   fromOnboarding?: boolean;
-  onComplete?: (matchId: number) => void;
+  onComplete?: (selected: { game: SelectedGame; date: string }) => void;
 }
 
 const GameMatchBottomSheet = ({
@@ -56,10 +46,20 @@ const GameMatchBottomSheet = ({
     onClose();
   };
 
-  const handleSubmit = async () => {
+  const handleSubmit = () => {
     if (selectedIdx === null) return;
+
     const selectedGame = gameSchedule[selectedIdx];
     if (!selectedGame) return;
+
+    if (fromOnboarding) {
+      handleClose();
+      onComplete?.({
+        game: selectedGame,
+        date,
+      });
+      return;
+    }
 
     const gaMatchType = activeType === TAB_TYPES.SINGLE ? 'one_to_one' : 'group';
     gaEvent('match_create_click', {
@@ -87,21 +87,7 @@ const GameMatchBottomSheet = ({
           }
 
           handleClose();
-
-          if (fromOnboarding) {
-            onComplete?.(response.matchId);
-          } else {
-            navigate(`${ROUTES.MATCH_CREATE(createdMatchId.toString())}?type=${queryType}`);
-          }
-        },
-        onError: (error) => {
-          const status = (error as AxiosError)?.response?.status;
-
-          if (status === MATCH_REQUEST_ERROR_MESSAGES.TOO_MANY_REQUESTS.status) {
-            showErrorToast(MATCH_REQUEST_ERROR_MESSAGES.TOO_MANY_REQUESTS.message, '8.3rem');
-          } else if (status === MATCH_REQUEST_ERROR_MESSAGES.DUPLICATE_MATCH.status) {
-            showErrorToast(MATCH_REQUEST_ERROR_MESSAGES.DUPLICATE_MATCH.message, '8.3rem');
-          }
+          navigate(`${ROUTES.MATCH_CREATE(createdMatchId)}?type=${queryType}`);
         },
       },
     );

--- a/src/shared/components/bottom-sheet/game-match/game-match-bottom-sheet.tsx
+++ b/src/shared/components/bottom-sheet/game-match/game-match-bottom-sheet.tsx
@@ -30,7 +30,6 @@ interface GameMatchBottomSheetProps {
   onClick?: (selectedId: number | null) => void;
   activeType: TabType;
   fromOnboarding?: boolean;
-  // groupRole?: string | null;  TODO: 추후 삭제
   onComplete?: (matchId: number) => void;
 }
 
@@ -41,7 +40,6 @@ const GameMatchBottomSheet = ({
   gameSchedule,
   activeType,
   fromOnboarding = false,
-  // groupRole,
   onComplete,
 }: GameMatchBottomSheetProps) => {
   const [selectedIdx, setSelectedIdx] = useState<number | null>(null);
@@ -50,7 +48,7 @@ const GameMatchBottomSheet = ({
   const createMatchMutation = useMutation(matchMutations.CREATE_MATCH());
 
   const disabled = selectedIdx === null || createMatchMutation.isPending;
-  const matchType = activeType === TAB_TYPES.SINGLE ? 'direct' : 'group';
+  const matchType = activeType === TAB_TYPES.SINGLE ? 'DIRECT' : 'GROUP';
   const queryType = activeType === TAB_TYPES.SINGLE ? 'single' : 'group';
 
   const handleClose = () => {
@@ -78,7 +76,7 @@ const GameMatchBottomSheet = ({
         onSuccess: (response) => {
           const createdMatchId = response.matchId.toString();
 
-          if (matchType === 'direct') {
+          if (matchType === 'DIRECT') {
             queryClient.invalidateQueries({
               queryKey: matchQueries.SINGLE_MATCH_LIST(date).queryKey,
             });

--- a/src/shared/constants/error-toast.ts
+++ b/src/shared/constants/error-toast.ts
@@ -21,3 +21,5 @@ export const NO_GAME_TOAST_MESSAGE = '해당 날짜에는 진행되는 경기가
 export const HAS_DONE_TOAST_MESSAGE = '이미 매칭을 만든 경기예요.';
 
 export const MY_MATCH_TOAST_MESSAGE = '내가 만든 매칭은 매칭현황에서 확인 가능해요.';
+
+export const CREATE_MATCH_TOAST_MESSAGE = '방금 만든 카드를 매칭 현황에서 확인해 보세요!  🎉 ';

--- a/src/shared/styles/global.css
+++ b/src/shared/styles/global.css
@@ -46,4 +46,8 @@
   body::-webkit-scrollbar {
     display: none; /* Chrome, Safari */
   }
+
+  .toast-text {
+  max-width: none !important;
+}
 }

--- a/src/shared/styles/global.css
+++ b/src/shared/styles/global.css
@@ -48,6 +48,6 @@
   }
 
   .toast-text {
-  max-width: none !important;
-}
+    max-width: none !important;
+  }
 }

--- a/src/shared/utils/show-error-toast.tsx
+++ b/src/shared/utils/show-error-toast.tsx
@@ -4,12 +4,13 @@ import { toast } from 'react-compact-toast';
 type ShowErrorToastOptions = {
   icon?: boolean;
   offset?: string;
+  className?: string;
 };
 
 const DEFAULT_AUTOCLOSE = 2000;
 
 const showErrorToastCore = (message: string, opts?: ShowErrorToastOptions) => {
-  const { icon = true } = opts ?? {};
+  const { icon = true, className = '' } = opts ?? {};
 
   toast({
     text: message,
@@ -17,8 +18,13 @@ const showErrorToastCore = (message: string, opts?: ShowErrorToastOptions) => {
     autoClose: DEFAULT_AUTOCLOSE,
     offset: opts?.offset,
     position: 'bottomCenter',
-    className:
-      '!min-h-[4.5rem] max-w-[calc(43rem-3.2rem)] w-[calc(100%-3.2rem)] cap_14_m text-gray-white rounded-[12px] bg-gray-700',
+    className: `
+      !min-h-[4.5rem]
+      max-w-[calc(43rem-3.2rem)]
+      w-[calc(100%-3.2rem)]
+      rounded-[12px]
+      ${className || 'cap_14_m text-gray-white bg-gray-700'}
+    `,
   });
 };
 


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #423 

## ☀️ New-insight

- “날짜 선택 → 경기 선택” 단계에서는 실제 매칭 생성 없이 선택 데이터를 보관하고, 마지막 COMPLETE 단계에서 버튼 클릭 시 서버 요청하는 구조가 더 명확하다다.
- React Router의 `navigate state`를 활용하면 특정 플로우에서 이동했을 때만 1회성 토스트를 노출할 수 있어, 전역 상태 없이도 자연스러운 후처리가 가능하다.

## 💎 PR Point

### ➊ 온보딩 매칭 생성 시점 변경

기존에는 `DATE_SELECT > GameMatchBottomSheet > 다음으로` 클릭 시 즉시 매칭 생성 API가 호출되었으나,
- 날짜 / 경기 선택 시 선택 데이터만 저장
- COMPLETE 단계 카드에 선택 정보 미리보기 렌더링
- `만들기` 버튼 클릭 시 실제 매칭 생성 API 호출
하도록 플로우를 변경했습니다. 

### ➋ COMPLETE 단계 카드 미리보기 구현

기존 matchId를 받아서 경기 정보를 렌더링하던 카드를 사용하였으나, 플로우 변경 후 매칭이 생성되지 않은 상태에서 카드를 렌더링해야 했습니다. 따라서 선택한 경기 정보와 유저의 프로필 정보를 모두 사용하여 매칭 생성 전에도 COMPLETE 단계에서 실제 생성될 카드와 동일한 UI를 확인할 수 있도록 수정했습니다.

### ➌ 생성 완료 후 홈 진입 토스트 처리

온보딩에서 매칭 생성 후 홈으로 이동하는 경우에만 토스트가 노출되도록 처리했습니다.

- `navigate(..., state)` 방식으로 1회성 플래그 전달
- 홈 진입 시 토스트 노출
- 이후 state 제거하여 재진입 시 중복 노출 방지

### ➍ 토스트 스타일 확장

홈 전용 토스트 디자인 적용을 위해 기존 공통 토스트 유틸을 확장했습니다.

- 커스텀 className
- 특정 화면에서만 별도 색상 / 폰트 적용 가능하도록 기존 라이브러리에 설정된 값 해제

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 매칭 생성 완료 시 홈에서 확인하라는 안내 토스트 추가 및 생성 흐름 개선(온보딩→홈에 토스트 표시).
  * 온보딩/하단 시트에서 경기 선택 시 경기+날짜 형태로 전달되어 생성 흐름이 간소화됨.

* **Style**
  * 게임 페이지 배경 색상 업데이트.
  * 토스트 텍스트 폭 제한 해제용 전역 스타일 추가.

* **Chores**
  * 토스트 호출 옵션에 클래스명 추가 지원.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->