### PR TITLE
feat: 프로필 이미지 관련 api 연결

### DIFF
--- a/src/pages/edit-profile/constants/edit-profile.ts
+++ b/src/pages/edit-profile/constants/edit-profile.ts
@@ -14,3 +14,6 @@ export const PROFILE_VIEWING_STYLE = [
     label: '직관먹방러',
   },
 ];
+
+export const DEFAULT_PROFILE_IMAGE_URL =
+  'https://mateball-file.s3.ap-northeast-2.amazonaws.com/profile.jpg';

--- a/src/pages/edit-profile/edit-profile.tsx
+++ b/src/pages/edit-profile/edit-profile.tsx
@@ -1,13 +1,16 @@
+import { imageMutations } from '@apis/image/image-mutations';
 import { userMutations } from '@apis/user/user-mutations';
 import { userQueries } from '@apis/user/user-queries';
 import Button from '@components/button/button/button';
 import Divider from '@components/divider/divider';
 import Icon from '@components/icon/icon';
 import Input from '@components/input/input';
+import { USER_KEY } from '@constants/query-key';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { cn } from '@libs/cn';
 import SelectionGroup from '@pages/edit-profile/components/selection-group';
 import {
+  DEFAULT_PROFILE_IMAGE_URL,
   PROFILE_SYNC_MATE,
   PROFILE_VIEWING_STYLE,
 } from '@pages/edit-profile/constants/edit-profile';
@@ -27,12 +30,13 @@ import {
   NICKNAME_PLACEHOLDER,
 } from '@pages/sign-up/constants/validation';
 import type { NicknameStatus } from '@pages/sign-up/types/nickname-types';
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
 const EditProfile = () => {
   const { data } = useQuery(userQueries.MATCH_CONDITION());
+  const { data: userInfo } = useQuery(userQueries.USER_INFO());
 
   const [team, setTeam] = useState<string | undefined>(undefined);
   const [mateTeam, setMateTeam] = useState<string | undefined>(undefined);
@@ -40,9 +44,18 @@ const EditProfile = () => {
   const [avgSeason, setAvgSeason] = useState('');
   const [isSubmit, setIsSubmit] = useState(false);
   const [nicknameStatus, setNicknameStatus] = useState<NicknameStatus>('idle');
+  const [profileImageUrl, setProfileImageUrl] = useState<string | null>(null);
 
   const { mutate: editProfile } = useMutation(userMutations.EDIT_PROFILE());
   const { mutate: editMatchCondition } = useMutation(userMutations.EDIT_MATCH_CONDITION());
+
+  // TODO: 추후 이미지 삭제 시 연결
+  // const deleteProfileImageMutation = useMutation({
+  //   ...imageMutations.DELETE_PROFILE_IMAGE(),
+  //   onSuccess: ({ profileImageUrl }) => {
+  //     setProfileImageUrl(profileImageUrl);
+  //   },
+  // });
 
   const {
     control,
@@ -120,6 +133,58 @@ const EditProfile = () => {
     }
   };
 
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const queryClient = useQueryClient();
+
+  const handleProfileImageClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const postProfileImageMutation = useMutation({
+    ...imageMutations.POST_PROFILE_IMAGE(),
+    onSuccess: ({ profileImageUrl }) => {
+      setProfileImageUrl(profileImageUrl);
+
+      queryClient.invalidateQueries({
+        queryKey: USER_KEY.INFO(),
+      });
+    },
+  });
+
+  const patchProfileImageMutation = useMutation({
+    ...imageMutations.PATCH_PROFILE_IMAGE(),
+    onSuccess: ({ profileImageUrl }) => {
+      setProfileImageUrl(profileImageUrl);
+
+      queryClient.invalidateQueries({
+        queryKey: USER_KEY.INFO(),
+      });
+    },
+  });
+
+  const hasCustomProfileImage =
+    Boolean(userInfo?.imgUrl) && userInfo?.imgUrl !== DEFAULT_PROFILE_IMAGE_URL;
+
+  const handleProfileImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const image = event.target.files?.[0];
+
+    if (!image) return;
+
+    if (hasCustomProfileImage) {
+      patchProfileImageMutation.mutate({ image });
+    } else {
+      postProfileImageMutation.mutate({ image });
+    }
+
+    event.target.value = '';
+  };
+
+  useEffect(() => {
+    if (userInfo?.imgUrl) {
+      setProfileImageUrl(userInfo.imgUrl);
+    }
+  }, [userInfo?.imgUrl]);
+
   return (
     <div className="h-full bg-gray-white px-[1.6rem] pt-[1.6rem] pb-[4rem]">
       <h2 className="subhead_18_sb mb-[1.6rem]">프로필 수정</h2>
@@ -128,10 +193,34 @@ const EditProfile = () => {
       <section>
         <div className="mb-[2.4rem] flex-col gap-[0.8rem]">
           <p className="body_16_m text-gray-black">프로필 이미지</p>
-          {/* TODO: 프로필 편집 api 연결 */}
           <div className="relative w-fit">
-            <Icon name="profile" size={6.4} />
-            <Icon name="camera" size={1.6} className="absolute right-0 bottom-0" />
+            <button
+              type="button"
+              onClick={handleProfileImageClick}
+              disabled={patchProfileImageMutation.isPending}
+              aria-label="프로필 이미지 수정"
+              className="relative w-fit"
+            >
+              {profileImageUrl ? (
+                <img
+                  src={profileImageUrl}
+                  alt="프로필 이미지"
+                  className="h-[6.4rem] w-[6.4rem] rounded-full object-cover"
+                />
+              ) : (
+                <Icon name="profile" size={6.4} />
+              )}
+
+              <Icon name="camera" size={1.6} className="absolute right-0 bottom-0" />
+            </button>
+
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/jpeg,image/jpg,image/png,image/webp"
+              onChange={handleProfileImageChange}
+              className="hidden"
+            />
           </div>
         </div>
 

--- a/src/pages/edit-profile/edit-profile.tsx
+++ b/src/pages/edit-profile/edit-profile.tsx
@@ -35,110 +35,16 @@ import { useEffect, useRef, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
 const EditProfile = () => {
+  const queryClient = useQueryClient();
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
   const { data } = useQuery(userQueries.MATCH_CONDITION());
   const { data: userInfo } = useQuery(userQueries.USER_INFO());
 
-  const [team, setTeam] = useState<string | undefined>(undefined);
-  const [mateTeam, setMateTeam] = useState<string | undefined>(undefined);
-  const [viewStyle, setViewStyle] = useState<string | undefined>(undefined);
-  const [avgSeason, setAvgSeason] = useState('');
-  const [isSubmit, setIsSubmit] = useState(false);
-  const [nicknameStatus, setNicknameStatus] = useState<NicknameStatus>('idle');
-  const [profileImageUrl, setProfileImageUrl] = useState<string | null>(null);
-
   const { mutate: editProfile } = useMutation(userMutations.EDIT_PROFILE());
   const { mutate: editMatchCondition } = useMutation(userMutations.EDIT_MATCH_CONDITION());
-
-  // TODO: 추후 이미지 삭제 시 연결
-  // const deleteProfileImageMutation = useMutation({
-  //   ...imageMutations.DELETE_PROFILE_IMAGE(),
-  //   onSuccess: ({ profileImageUrl }) => {
-  //     setProfileImageUrl(profileImageUrl);
-  //   },
-  // });
-
-  const {
-    control,
-    formState: { errors, isSubmitting },
-    trigger,
-    getValues,
-    watch,
-  } = useForm<EditProfileValues>({
-    resolver: zodResolver(EditProfileSchema),
-    mode: 'onChange',
-    defaultValues: { nickname: '', introduction: '' },
-  });
-
-  const nicknameVal = watch('nickname', '');
-  const introductionVal = watch('introduction', '');
-
   const { mutateAsync: checkNickname } = useMutation(userMutations.NICKNAME_CHECK());
-  const submitNickname = async () => {
-    const ok = await trigger('nickname');
-    if (!ok) return;
-    editProfile({ field: '닉네임', value: getValues('nickname').trim() });
-  };
-
-  const submitInformation = async () => {
-    const ok = await trigger('introduction');
-    if (!ok) return;
-    editProfile({ field: '소개', value: getValues('introduction').trim() });
-  };
-
-  const initial = {
-    team: data?.team ?? '',
-    mateTeam: data?.teamAllowed ?? '',
-    viewStyle: data?.style ?? '',
-    avgSeason: data?.avgSeason ?? 0,
-  };
-
-  const teamValue = team ?? initial.team;
-  const viewStyleValue = viewStyle ?? initial.viewStyle;
-  const mateTeamValue = (teamValue === NO_TEAM_OPTION ? '' : (mateTeam ?? initial.mateTeam)) ?? '';
-  const avgSeasonValue = avgSeason === '' ? initial.avgSeason : Number(avgSeason);
-
-  const isMatchDirty =
-    teamValue !== initial.team ||
-    mateTeamValue !== initial.mateTeam ||
-    viewStyleValue !== initial.viewStyle ||
-    avgSeasonValue !== initial.avgSeason;
-
-  const isSubmitDisabled = !isMatchDirty || isSubmit;
-
-  const handleSaveClick = () => {
-    if (!isMatchDirty) return;
-    setIsSubmit(true);
-
-    editMatchCondition({
-      team: teamValue,
-      style: viewStyleValue,
-      teamAllowed: teamValue === NO_TEAM_OPTION ? null : mateTeamValue || null,
-      avgSeason: avgSeasonValue,
-    });
-  };
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: reset nickname status whenever value changes
-  useEffect(() => {
-    setNicknameStatus('idle');
-  }, [nicknameVal]);
-
-  const handleCheckNickname = async () => {
-    if (errors.nickname || nicknameVal.trim().length < 2) return;
-    setNicknameStatus('checking');
-    try {
-      const available = await checkNickname({ nickname: nicknameVal });
-      setNicknameStatus(available ? 'available' : 'duplicate');
-    } catch {
-      setNicknameStatus('idle');
-    }
-  };
-
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const queryClient = useQueryClient();
-
-  const handleProfileImageClick = () => {
-    fileInputRef.current?.click();
-  };
 
   const postProfileImageMutation = useMutation({
     ...imageMutations.POST_PROFILE_IMAGE(),
@@ -162,8 +68,105 @@ const EditProfile = () => {
     },
   });
 
+  // TODO: 추후 이미지 삭제 시 연결
+  // const deleteProfileImageMutation = useMutation({
+  //   ...imageMutations.DELETE_PROFILE_IMAGE(),
+  //   onSuccess: ({ profileImageUrl }) => {
+  //     setProfileImageUrl(profileImageUrl);
+  //   },
+  // });
+
+  const {
+    control,
+    formState: { errors, isSubmitting },
+    trigger,
+    getValues,
+    watch,
+  } = useForm<EditProfileValues>({
+    resolver: zodResolver(EditProfileSchema),
+    mode: 'onChange',
+    defaultValues: { nickname: '', introduction: '' },
+  });
+
+  const [team, setTeam] = useState<string | undefined>(undefined);
+  const [mateTeam, setMateTeam] = useState<string | undefined>(undefined);
+  const [viewStyle, setViewStyle] = useState<string | undefined>(undefined);
+  const [avgSeason, setAvgSeason] = useState('');
+  const [isSubmit, setIsSubmit] = useState(false);
+  const [nicknameStatus, setNicknameStatus] = useState<NicknameStatus>('idle');
+  const [profileImageUrl, setProfileImageUrl] = useState<string | null>(null);
+
+  const nicknameVal = watch('nickname', '');
+  const introductionVal = watch('introduction', '');
+
+  const initial = {
+    team: data?.team ?? '',
+    mateTeam: data?.teamAllowed ?? '',
+    viewStyle: data?.style ?? '',
+    avgSeason: data?.avgSeason ?? 0,
+  };
+
+  const teamValue = team ?? initial.team;
+  const viewStyleValue = viewStyle ?? initial.viewStyle;
+  const mateTeamValue = (teamValue === NO_TEAM_OPTION ? '' : (mateTeam ?? initial.mateTeam)) ?? '';
+  const avgSeasonValue = avgSeason === '' ? initial.avgSeason : Number(avgSeason);
+
+  const isMatchDirty =
+    teamValue !== initial.team ||
+    mateTeamValue !== initial.mateTeam ||
+    viewStyleValue !== initial.viewStyle ||
+    avgSeasonValue !== initial.avgSeason;
+
+  const isSubmitDisabled = !isMatchDirty || isSubmit;
+
   const hasCustomProfileImage =
     Boolean(userInfo?.imgUrl) && userInfo?.imgUrl !== DEFAULT_PROFILE_IMAGE_URL;
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset nickname status whenever value changes
+  useEffect(() => {
+    setNicknameStatus('idle');
+  }, [nicknameVal]);
+
+  useEffect(() => {
+    if (userInfo?.imgUrl) {
+      setProfileImageUrl(userInfo.imgUrl);
+    }
+  }, [userInfo?.imgUrl]);
+
+  const submitNickname = async () => {
+    const ok = await trigger('nickname');
+    if (!ok) return;
+    editProfile({ field: '닉네임', value: getValues('nickname').trim() });
+  };
+
+  const submitInformation = async () => {
+    const ok = await trigger('introduction');
+    if (!ok) return;
+    editProfile({ field: '소개', value: getValues('introduction').trim() });
+  };
+
+  const handleSaveClick = () => {
+    if (!isMatchDirty) return;
+    setIsSubmit(true);
+
+    editMatchCondition({
+      team: teamValue,
+      style: viewStyleValue,
+      teamAllowed: teamValue === NO_TEAM_OPTION ? null : mateTeamValue || null,
+      avgSeason: avgSeasonValue,
+    });
+  };
+
+  const handleCheckNickname = async () => {
+    if (errors.nickname || nicknameVal.trim().length < 2) return;
+    setNicknameStatus('checking');
+    try {
+      const available = await checkNickname({ nickname: nicknameVal });
+      setNicknameStatus(available ? 'available' : 'duplicate');
+    } catch {
+      setNicknameStatus('idle');
+    }
+  };
 
   const handleProfileImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const image = event.target.files?.[0];
@@ -179,11 +182,9 @@ const EditProfile = () => {
     event.target.value = '';
   };
 
-  useEffect(() => {
-    if (userInfo?.imgUrl) {
-      setProfileImageUrl(userInfo.imgUrl);
-    }
-  }, [userInfo?.imgUrl]);
+  const handleProfileImageClick = () => {
+    fileInputRef.current?.click();
+  };
 
   return (
     <div className="h-full bg-gray-white px-[1.6rem] pt-[1.6rem] pb-[4rem]">

--- a/src/pages/edit-profile/edit-profile.tsx
+++ b/src/pages/edit-profile/edit-profile.tsx
@@ -198,7 +198,7 @@ const EditProfile = () => {
             <button
               type="button"
               onClick={handleProfileImageClick}
-              disabled={patchProfileImageMutation.isPending}
+              disabled={patchProfileImageMutation.isPending || postProfileImageMutation.isPending}
               aria-label="프로필 이미지 수정"
               className="relative w-fit"
             >

--- a/src/pages/match/components/match-tab-pannel.tsx
+++ b/src/pages/match/components/match-tab-pannel.tsx
@@ -83,7 +83,7 @@ const MatchTabPanel = ({ isCreatedTab, onCardClick }: MatchTabPanelProps) => {
         cards.map((card) => (
           <div
             key={`${card.type}-${card.id}`}
-            // biome-ignore lint/a11y/useSemanticElements: <explanation>
+            // biome-ignore lint/a11y/useSemanticElements: 카드 전체를 클릭 영역으로 사용하기 위해 div에 button role 부여
             role="button"
             tabIndex={0}
             onClick={() => handleCardClick(card)}

--- a/src/pages/profile/components/profile-card.tsx
+++ b/src/pages/profile/components/profile-card.tsx
@@ -28,7 +28,7 @@ const ProfileCard = ({ nickname, imgUrl, team, style, matchCnt, avgSeason }: Pro
           <img
             src={imgUrl}
             alt={`${nickname} 프로필 이미지`}
-            className="h-[6rem] w-[6rem] rounded-[60px]"
+            className="h-[6rem] w-[6rem] rounded-[60px] object-cover"
           />
           <div className="flex-col gap-[0.4rem]">
             <p className="subhead_18_sb text-gray-white">{nickname}</p>

--- a/src/pages/sign-up/components/signup-step.tsx
+++ b/src/pages/sign-up/components/signup-step.tsx
@@ -1,3 +1,4 @@
+import { imageMutations } from '@apis/image/image-mutations';
 import { userMutations } from '@apis/user/user-mutations';
 import Button from '@components/button/button/button';
 import Icon from '@components/icon/icon';
@@ -22,7 +23,7 @@ import { type UserInfoFormValues, UserInfoSchema } from '@pages/sign-up/schema/v
 import type { NicknameStatus } from '@pages/sign-up/types/nickname-types';
 import { ROUTES } from '@routes/routes-config';
 import { useMutation } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -34,6 +35,7 @@ import type { postUserInfoRequest } from '@/shared/types/user-types';
 const SignupStep = () => {
   const navigate = useNavigate();
   const { refreshUserStatus } = useAuth();
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const {
     register,
@@ -53,6 +55,7 @@ const SignupStep = () => {
   const informationValue = watch('introduction');
 
   const [nicknameStatus, setNicknameStatus] = useState<NicknameStatus>('idle');
+  const [profileImageUrl, setProfileImageUrl] = useState<string | null>(null);
 
   const hasNicknameError = !!errors.nickname || nicknameStatus === 'duplicate';
 
@@ -63,6 +66,12 @@ const SignupStep = () => {
   const userInfoMutation = useMutation(userMutations.USER_INFO());
   const agreementInfoMutaion = useMutation(userMutations.AGREEMENT_INFO());
   const { mutateAsync: checkNickname } = useMutation(userMutations.NICKNAME_CHECK());
+  const postProfileImageMutation = useMutation({
+    ...imageMutations.POST_PROFILE_IMAGE(),
+    onSuccess: ({ profileImageUrl }) => {
+      setProfileImageUrl(profileImageUrl);
+    },
+  });
 
   const informationLength = informationValue.length ?? 0;
 
@@ -123,6 +132,20 @@ const SignupStep = () => {
     }
   };
 
+  const handleProfileImageClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleProfileImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const image = event.target.files?.[0];
+
+    if (!image) return;
+
+    postProfileImageMutation.mutate({ image });
+
+    event.target.value = '';
+  };
+
   const nicknameValidationMessage = getNicknameValidationMessage(
     nicknameStatus,
     errors.nickname,
@@ -153,10 +176,34 @@ const SignupStep = () => {
             <p className="body_16_m text-gray-black">
               프로필 이미지 <span className="text-gray-500">(선택)</span>
             </p>
-            {/* TODO: 프로필 편집 api 연결 */}
             <div className="relative w-fit">
-              <Icon name="profile" size={6.4} />
-              <Icon name="camera" size={1.6} className="absolute right-0 bottom-0" />
+              <button
+                type="button"
+                onClick={handleProfileImageClick}
+                disabled={postProfileImageMutation.isPending}
+                aria-label="프로필 이미지 등록"
+                className="relative w-fit"
+              >
+                {profileImageUrl ? (
+                  <img
+                    src={profileImageUrl}
+                    alt="프로필 이미지"
+                    className="h-[6.4rem] w-[6.4rem] rounded-full object-cover object-center"
+                  />
+                ) : (
+                  <Icon name="profile" size={6.4} />
+                )}
+
+                <Icon name="camera" size={1.6} className="absolute right-0 bottom-0" />
+              </button>
+
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/jpeg,image/jpg,image/png,image/webp"
+                onChange={handleProfileImageChange}
+                className="hidden"
+              />
             </div>
           </div>
           <div className="flex-col gap-[0.8rem]">

--- a/src/shared/apis/base/http.ts
+++ b/src/shared/apis/base/http.ts
@@ -19,3 +19,23 @@ export function put<T>(...args: Parameters<typeof instance.put>): Promise<T> {
 export function del<T>(...args: Parameters<typeof instance.delete>): Promise<T> {
   return instance.delete<T>(...args).then((res) => res.data);
 }
+
+export function postFormData<T>(url: string, formData: FormData): Promise<T> {
+  return instance
+    .post<T>(url, formData, {
+      headers: {
+        'Content-Type': undefined,
+      },
+    })
+    .then((res) => res.data);
+}
+
+export function patchFormData<T>(url: string, formData: FormData): Promise<T> {
+  return instance
+    .patch<T>(url, formData, {
+      headers: {
+        'Content-Type': undefined,
+      },
+    })
+    .then((res) => res.data);
+}

--- a/src/shared/apis/image/image-mutations.ts
+++ b/src/shared/apis/image/image-mutations.ts
@@ -1,0 +1,54 @@
+import { patchFormData, postFormData } from '@apis/base/http';
+import { END_POINT } from '@constants/api';
+import { IMAGE_KEY } from '@constants/query-key';
+import { mutationOptions } from '@tanstack/react-query';
+import type { ApiResponse } from '@/shared/types/base-types';
+import type {
+  PatchProfileImageRequest,
+  PatchProfileImageResponse,
+  PostProfileImageRequest,
+  PostProfileImageResponse,
+} from '@/shared/types/image-types';
+
+const createProfileImageFormData = (image: File) => {
+  const formData = new FormData();
+  formData.append('file', image);
+
+  return formData;
+};
+
+export const imageMutations = {
+  POST_PROFILE_IMAGE: () =>
+    mutationOptions<PostProfileImageResponse, Error, PostProfileImageRequest>({
+      mutationKey: IMAGE_KEY.PROFILE.POST(),
+      mutationFn: async ({ image }) => {
+        const res = await postFormData<ApiResponse<PostProfileImageResponse>>(
+          END_POINT.POST_PROFILE_IMAGE,
+          createProfileImageFormData(image),
+        );
+
+        if (!res.data) {
+          throw new Error('프로필 이미지 업로드 응답 데이터가 없습니다.');
+        }
+
+        return res.data;
+      },
+    }),
+
+  PATCH_PROFILE_IMAGE: () =>
+    mutationOptions<PatchProfileImageResponse, Error, PatchProfileImageRequest>({
+      mutationKey: IMAGE_KEY.PROFILE.PATCH(),
+      mutationFn: async ({ image }) => {
+        const res = await patchFormData<ApiResponse<PatchProfileImageResponse>>(
+          END_POINT.PATCH_PROFILE_IMAGE,
+          createProfileImageFormData(image),
+        );
+
+        if (!res.data) {
+          throw new Error('프로필 이미지 수정 응답 데이터가 없습니다.');
+        }
+
+        return res.data;
+      },
+    }),
+};

--- a/src/shared/apis/image/image-mutations.ts
+++ b/src/shared/apis/image/image-mutations.ts
@@ -1,9 +1,10 @@
-import { patchFormData, postFormData } from '@apis/base/http';
+import { del, patchFormData, postFormData } from '@apis/base/http';
 import { END_POINT } from '@constants/api';
 import { IMAGE_KEY } from '@constants/query-key';
 import { mutationOptions } from '@tanstack/react-query';
 import type { ApiResponse } from '@/shared/types/base-types';
 import type {
+  DeleteProfileImageResponse,
   PatchProfileImageRequest,
   PatchProfileImageResponse,
   PostProfileImageRequest,
@@ -46,6 +47,22 @@ export const imageMutations = {
 
         if (!res.data) {
           throw new Error('프로필 이미지 수정 응답 데이터가 없습니다.');
+        }
+
+        return res.data;
+      },
+    }),
+
+  DELETE_PROFILE_IMAGE: () =>
+    mutationOptions<DeleteProfileImageResponse, Error, void>({
+      mutationKey: IMAGE_KEY.PROFILE.DELETE(),
+      mutationFn: async () => {
+        const res = await del<ApiResponse<DeleteProfileImageResponse>>(
+          END_POINT.DELETE_PROFILE_IMAGE,
+        );
+
+        if (!res.data) {
+          throw new Error('프로필 이미지 삭제 응답 데이터가 없습니다.');
         }
 
         return res.data;

--- a/src/shared/constants/api.ts
+++ b/src/shared/constants/api.ts
@@ -57,4 +57,9 @@ export const END_POINT = {
   GET_UNREAD_ALARMS: '/v2/users/alarm',
   POST_READ_ALARM: (matchId: number | string) => `/v2/users/alarm/${matchId}`,
   POST_READ_ALL_ALARMS: '/v2/users/alarms',
+
+  // 프로필
+  POST_PROFILE_IMAGE: '/v3/users/profile-image',
+  PATCH_PROFILE_IMAGE: '/v3/users/profile-image',
+  DELETE_PROFILE_IMAGE: '/v3/users/profile-image',
 };

--- a/src/shared/constants/query-key.ts
+++ b/src/shared/constants/query-key.ts
@@ -75,3 +75,14 @@ export const ALARM_KEY = {
   HAS_UNREAD: ['alarms', 'hasUnread'] as const,
   READ_ALL: () => ['alarms', 'read-all'] as const,
 };
+
+export const IMAGE_KEY = {
+  ALL: ['image'] as const,
+
+  PROFILE: {
+    ALL: () => [...IMAGE_KEY.ALL, 'profile'] as const,
+    POST: () => [...IMAGE_KEY.ALL, 'profile', 'post'] as const,
+    PATCH: () => [...IMAGE_KEY.ALL, 'profile', 'patch'] as const,
+    DELETE: () => [...IMAGE_KEY.ALL, 'profile', 'delete'] as const,
+  },
+};

--- a/src/shared/types/image-types.ts
+++ b/src/shared/types/image-types.ts
@@ -1,0 +1,32 @@
+/**
+ * 프로필 이미지 업로드
+ * POST /v3/users/profile-image
+ */
+export interface PostProfileImageRequest {
+  image: File;
+}
+
+export interface PostProfileImageResponse {
+  profileImageKey: string;
+  profileImageUrl: string;
+}
+
+/**
+ * 프로필 이미지 수정
+ * PATCH /v3/users/profile-image
+ */
+export interface PatchProfileImageRequest {
+  image: File;
+}
+
+export interface PatchProfileImageResponse {
+  profileImageUrl: string;
+}
+
+/**
+ * 프로필 이미지 삭제
+ * DELETE /v3/users/profile-image
+ */
+export interface DeleteProfileImageResponse {
+  profileImageUrl: string;
+}


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #418 

## ☀️ New-insight

1. multipart/form-data 요청 시 FormData key 이름이 서버에서 기대하는 값과 정확히 일치해야 한다.
2. 프로필 이미지 업로드 api는 Request Body 필드명이 image가 아니라 file이었고, key 이름이 다를 경우 서버에서 500에러가 발생했다.
3. 기본 이미지 URL과 현재 imgUrl을 비교하여 커스텀 이미지 여부를 판단하도록 구현했다.

## 💎 PR Point

### 1. 프로필 이미지 API 연동
`POST /v3/users/profile-image`
`PATCH /v3/users/profile-image`
`DELETE /v3/users/profile-image`

프로필 이미지 업로드, 수정, 삭제 api를 react query mutation으로 구현했습니다.
다만 프로필 이미지 삭제의 경우 다른 트리거가 필요해서 연동은 하지 않은 상태입니다.

### 2. FormData 전용 HTTP 함수 추가
multipart/form-data 요청을 위해 postFormData, patchFormData 유틸 함수를 추가했습니다.

### 3. EditProfile 이미지 업로드 연결
프로필 이미지 영역 클릭 시 파일 선택창이 열리도록 구현하고, 선택한 이미지를 업로드하도록 연결했습니다.

- 최초 등록 → POST
- 기존 커스텀 이미지 수정 → PATCH

### 4. POST/PATCH 분기 로직
기본 이미지 URL과 현재 imgUrl을 비교하여 커스텀 이미지 여부를 판단합니다.

```tsx
const hasCustomProfileImage =
  Boolean(userInfo?.imgUrl) &&
  userInfo.imgUrl !== DEFAULT_PROFILE_IMAGE_URL;
```

## 📸 Screenshot
프로필 이미지 최초 등록시

https://github.com/user-attachments/assets/b0408283-9824-49ce-980a-7c731313b2c6

프로필 이미지 변경시

https://github.com/user-attachments/assets/7fefd4c6-2a9d-49de-85ad-71afaaa4b489

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 프로필 이미지 업로드/변경 기능 추가: 프로필 사진 클릭으로 새 이미지 업로드 및 기존 이미지 교체 가능.
  * 회원가입 화면에서도 프로필 이미지 업로드 및 미리보기 지원.

* **개선사항**
  * 프로필 이미지 표시 방식 개선(이미지 크롭/표시 최적화) 및 카메라 아이콘 오버레이로 직관적 편집 경험 제공.
  * 업로드 중 버튼 비활성화로 중복 작업 방지.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MATEBALL/MATEBALL-CLIENT/pull/425)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->