### PR TITLE
fix: 매칭 요청 관련 사항들 수정

### DIFF
--- a/src/pages/match/components/match-tab-pannel.tsx
+++ b/src/pages/match/components/match-tab-pannel.tsx
@@ -1,6 +1,7 @@
 import { matchMutations } from '@apis/match/match-mutations';
 import { matchQueries } from '@apis/match/match-queries';
 import Card from '@components/card/match-card/card';
+import { MATCH_STATE } from '@components/card/match-card/constants/status';
 import type { MatchCardProps } from '@components/card/match-card/types/card';
 import EmptyView from '@components/ui/empty-view';
 import { MATCH_PENDING_TOAST_MESSAGES } from '@constants/error-toast';
@@ -55,7 +56,10 @@ const MatchTabPanel = ({ isCreatedTab, onCardClick }: MatchTabPanelProps) => {
     }
 
     try {
-      if (card.statusLabel === '매칭 완료' || card.statusLabel === '수락 완료') {
+      if (
+        card.statusLabel === MATCH_STATE.MATCHING_COMPLETE ||
+        card.statusLabel === MATCH_STATE.APPROVAL_COMPLETE
+      ) {
         await patchStageMutation.mutateAsync(card.id);
       }
       navigate(`${ROUTES.RESULT(card.id.toString())}?type=${query}&cardtype=${card.type}`);

--- a/src/pages/match/components/match-tab-pannel.tsx
+++ b/src/pages/match/components/match-tab-pannel.tsx
@@ -54,12 +54,6 @@ const MatchTabPanel = ({ isCreatedTab, onCardClick }: MatchTabPanelProps) => {
       return;
     }
 
-    // const toastMsg = getPendingToast(card.statusLabel, card.type);
-    // if (toastMsg) {
-    //   showErrorToast(toastMsg, '8.9rem', false);
-    //   return;
-    // }
-
     try {
       if (card.statusLabel === '매칭 완료' || card.statusLabel === '수락 완료') {
         await patchStageMutation.mutateAsync(card.id);

--- a/src/pages/match/components/match-tab-pannel.tsx
+++ b/src/pages/match/components/match-tab-pannel.tsx
@@ -42,7 +42,10 @@ const MatchTabPanel = ({ isCreatedTab, onCardClick }: MatchTabPanelProps) => {
   const handleCardClick = async (card: MatchableCardProps) => {
     onCardClick?.(card);
 
-    if (!card.hasUpdate) {
+    const query =
+      isCreatedTab && card.hasUpdate ? 'received' : CLICKABLE_STATUS_MAP[card.statusLabel ?? ''];
+
+    if (!query) {
       const message = isCreatedTab
         ? MATCH_PENDING_TOAST_MESSAGES.REQUEST_WAITING
         : MATCH_PENDING_TOAST_MESSAGES.APPROVAL_WAITING;
@@ -57,11 +60,8 @@ const MatchTabPanel = ({ isCreatedTab, onCardClick }: MatchTabPanelProps) => {
     //   return;
     // }
 
-    const query = CLICKABLE_STATUS_MAP[card.statusLabel ?? ''];
-    if (!query) return;
-
     try {
-      if (card.statusLabel === '승인 완료') {
+      if (card.statusLabel === '매칭 완료' || card.statusLabel === '수락 완료') {
         await patchStageMutation.mutateAsync(card.id);
       }
       navigate(`${ROUTES.RESULT(card.id.toString())}?type=${query}&cardtype=${card.type}`);

--- a/src/pages/match/components/match-tab-pannel.tsx
+++ b/src/pages/match/components/match-tab-pannel.tsx
@@ -65,7 +65,7 @@ const MatchTabPanel = ({ isCreatedTab, onCardClick }: MatchTabPanelProps) => {
   };
 
   return (
-    <div className="z-[var(--z-under-header-section)] flex-col gap-[1.2rem] px-[1.6rem] pt-[1.6rem]">
+    <div className="flex-col gap-[1.2rem] px-[1.6rem] pt-[1.6rem]">
       {cards.length === 0 ? (
         <EmptyView
           iconName="empty"

--- a/src/pages/match/components/mate-carousel.tsx
+++ b/src/pages/match/components/mate-carousel.tsx
@@ -49,7 +49,7 @@ const MateCarousel = ({ mates, currentIndex, onDotClick, isGroupMatching }: Mate
         ))}
       </ul>
 
-      {isGroupMatching && (
+      {isGroupMatching && mates.length > 1 && (
         <div className="flex-row-center">
           <CarouselIndicator
             ids={mates.map((mate) => `mate-${mate.id}`)}

--- a/src/pages/match/components/mate.tsx
+++ b/src/pages/match/components/mate.tsx
@@ -58,7 +58,6 @@ const Mate = ({ matchId, isGroupMatching = true }: MateProps) => {
     enabled: !!matchId,
   });
   const mates = (data?.results || []).map(mapMateData);
-  // TODO: 네이밍 수정
   const leader = data?.leader ?? '';
 
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -74,7 +73,6 @@ const Mate = ({ matchId, isGroupMatching = true }: MateProps) => {
   return (
     <div className="h-full flex-col-between bg-gray-white">
       <section className="w-full flex-col-center gap-[3.9rem] pt-[4.65rem]">
-        {/* TODO: 서버 응답값 수정 후 nickname 연동 */}
         <MateHeader nickname={leader} isGroupMatching={isGroupMatching} />
         <MateCarousel
           mates={mates}

--- a/src/pages/match/constants/matching.ts
+++ b/src/pages/match/constants/matching.ts
@@ -51,6 +51,6 @@ export const MATCHING_GUIDE_CREATED_DESCRIPTION =
 
 export const CLICKABLE_STATUS_MAP: Record<string, string> = {
   '매칭 완료': 'success',
-  '승인 완료': 'agree',
+  '수락 완료': 'agree',
   새요청: 'received',
 };

--- a/src/pages/match/constants/matching.ts
+++ b/src/pages/match/constants/matching.ts
@@ -52,5 +52,5 @@ export const MATCHING_GUIDE_CREATED_DESCRIPTION =
 export const CLICKABLE_STATUS_MAP: Record<string, string> = {
   '매칭 완료': 'success',
   '승인 완료': 'agree',
-  '새요청': 'received',
+  새요청: 'received',
 };

--- a/src/pages/match/constants/matching.ts
+++ b/src/pages/match/constants/matching.ts
@@ -52,5 +52,5 @@ export const MATCHING_GUIDE_CREATED_DESCRIPTION =
 export const CLICKABLE_STATUS_MAP: Record<string, string> = {
   '매칭 완료': 'success',
   '승인 완료': 'agree',
-  '새 요청': 'received',
+  '새요청': 'received',
 };

--- a/src/pages/match/match.tsx
+++ b/src/pages/match/match.tsx
@@ -21,7 +21,7 @@ const Match = () => {
 
   return (
     <div className="h-full grow flex-col bg-gray-black">
-      <nav className="sticky top-0 z-[var(--z-under-header-section)] w-full bg-gray-black">
+      <nav className="sticky top-0 z-[var(--z-header)] w-full bg-gray-black">
         <ul className={`flex items-center ${tabStyle.gap}`}>
           {MATCH_TAB_LIST.map((tab) => (
             <TabItem

--- a/src/pages/match/utils/match-status.ts
+++ b/src/pages/match/utils/match-status.ts
@@ -23,7 +23,7 @@ export const fillTabItems = ['전체', '대기 중', '완료', '실패'];
 export const getPendingToast = (status?: string): string | '' => {
   if (!status) return '';
   if (status === '요청 대기 중') return MATCH_PENDING_TOAST_MESSAGES.REQUEST_WAITING;
-  if (status === '승인 대기 중') MATCH_PENDING_TOAST_MESSAGES.APPROVAL_WAITING;
+  if (status === '승인 대기 중') return MATCH_PENDING_TOAST_MESSAGES.APPROVAL_WAITING;
 
   return '';
 };

--- a/src/pages/result/components/matching-receive-view.tsx
+++ b/src/pages/result/components/matching-receive-view.tsx
@@ -11,18 +11,13 @@ import { fillTabItems } from '@pages/match/utils/match-status';
 import { ERROR_MESSAGE, MATCHING_HEADER_MESSAGE } from '@pages/result/constants/matching-result';
 import { ROUTES } from '@routes/routes-config';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 const MatchingReceiveView = () => {
   const { matchId } = useParams();
   const navigate = useNavigate();
-  const [params] = useSearchParams();
-  const cardType = params.get('cardtype');
-  const isGroupMatching = cardType === 'group';
 
-  usePreventBackNavigation(
-    `${ROUTES.MATCH}?tab=${cardType === 'group' ? '그룹' : '1:1'}&filter=전체`,
-  );
+  usePreventBackNavigation(`${ROUTES.MATCH}?tab=생성한 매칭&filter=전체`);
 
   const parsedId = Number(matchId);
   const { mutate: acceptMatch } = useMutation(matchMutations.MATCH_ACCEPT());
@@ -60,11 +55,7 @@ const MatchingReceiveView = () => {
   const handleAccept = () => {
     acceptMatch(parsedId, {
       onSuccess: () => {
-        if (isGroupMatching) {
-          navigate(`${ROUTES.MATCH}?tab=그룹&filter=전체`);
-        } else {
-          navigate(`${ROUTES.RESULT(matchId)}?type=success`);
-        }
+        navigate(`${ROUTES.MATCH}?tab=생성한 매칭&filter=전체`);
 
         fillTabItems.forEach((label) => {
           queryClient.invalidateQueries({ queryKey: MATCH_KEY.STATUS.SINGLE(label) });
@@ -78,12 +69,12 @@ const MatchingReceiveView = () => {
   };
 
   return (
-    <div className="h-full flex-col-between overflow-hidden">
-      <div className="w-full flex-col-center gap-[4rem] px-[1.6rem] pt-[4rem]">
+    <div className="h-full flex-col-between overflow-hidden bg-gray-white">
+      <div className="w-full flex-col-center gap-[4rem] px-[1.6rem] pt-[4.8rem]">
         <section className="gap-[0.8rem] text-center">
           <h1 className="title_24_sb text-gray-black">{MATCHING_HEADER_MESSAGE}</h1>
         </section>
-        <Card {...detailedCard} className="w-full" />
+        <Card {...detailedCard} type="detailed" color="detailed" className="w-full" />
       </div>
 
       <section className="w-full flex-row-center gap-[0.8rem] p-[1.6rem]">

--- a/src/pages/result/components/matching-receive-view.tsx
+++ b/src/pages/result/components/matching-receive-view.tsx
@@ -96,10 +96,10 @@ const MatchingReceiveView = () => {
           size="L"
           variant="skyblue"
           className="w-full"
-          label="요청 거절하기"
+          label="요청 거절"
           onClick={handleReject}
         />
-        <Button size="L" className="w-full" label="요청 수락하기" onClick={handleAccept} />
+        <Button size="L" className="w-full" label="요청 수락" onClick={handleAccept} />
       </section>
     </div>
   );

--- a/src/pages/result/components/matching-receive-view.tsx
+++ b/src/pages/result/components/matching-receive-view.tsx
@@ -81,12 +81,7 @@ const MatchingReceiveView = () => {
     <div className="h-full flex-col-between overflow-hidden">
       <div className="w-full flex-col-center gap-[4rem] px-[1.6rem] pt-[4rem]">
         <section className="gap-[0.8rem] text-center">
-          <h1 className="title_24_sb text-gray-black">{MATCHING_HEADER_MESSAGE.description}</h1>
-          <p className="body_16_m whitespace-pre-line text-gray-600">
-            {isGroupMatching
-              ? MATCHING_HEADER_MESSAGE.group.subDescription
-              : MATCHING_HEADER_MESSAGE.single.subDescription}
-          </p>
+          <h1 className="title_24_sb text-gray-black">{MATCHING_HEADER_MESSAGE}</h1>
         </section>
         <Card {...detailedCard} className="w-full" />
       </div>

--- a/src/pages/result/components/sent-view.tsx
+++ b/src/pages/result/components/sent-view.tsx
@@ -13,7 +13,7 @@ const SentView = () => {
   const handleGoMatch = () => navigate(ROUTES.MATCH);
 
   return (
-    <div className="h-full flex-col-between">
+    <div className="h-full flex-col-between pt-[9.6rem]">
       <section className="flex-col-center gap-[4rem] pt-[4rem]">
         <h2 className="title_24_sb">매칭 요청이 전송되었어요!</h2>
         <div className="h-[16rem] w-[16rem] flex-row-center">

--- a/src/pages/result/components/sent-view.tsx
+++ b/src/pages/result/components/sent-view.tsx
@@ -10,7 +10,9 @@ const SentView = () => {
 
   const navigate = useNavigate();
   const handleGoHome = () => navigate(ROUTES.HOME);
-  const handleGoMatch = () => navigate(ROUTES.MATCH);
+  const handleGoMatch = () => {
+    navigate(`${ROUTES.MATCH}?tab=요청한 매칭`);
+  };
 
   return (
     <div className="h-full flex-col-between pt-[9.6rem]">

--- a/src/pages/result/constants/matching-result.ts
+++ b/src/pages/result/constants/matching-result.ts
@@ -1,13 +1,5 @@
-export const MATCHING_HEADER_MESSAGE = {
-  description: '매칭 요청이 도착했어요!',
-  group: {
-    subDescription:
-      '모든 그룹원이 수락하면 그룹원이 돼요.\n진행 과정은 ‘매칭 현황’에서 확인할 수 있어요!',
-  },
-  single: {
-    subDescription: '상대의 정보를 확인하고, 매칭을 이어가 보세요.',
-  },
-};
+export const MATCHING_HEADER_MESSAGE = '매칭 요청이 도착했어요!';
+
 export const ERROR_MESSAGE = '매칭 정보를 불러올 수 없습니다.\n다른 매칭으로 확인해 주세요.';
 
 export const ENTER_CHAT_COOLDOWN_MS = 800;

--- a/src/shared/apis/match/match-queries.ts
+++ b/src/shared/apis/match/match-queries.ts
@@ -216,9 +216,28 @@ export const matchQueries = {
   MATCH_DETAIL: (matchId: number, newRequest?: boolean) =>
     queryOptions<getMatchDetailResponse>({
       queryKey: [MATCH_KEY.DETAIL(matchId), { newRequest }],
-      queryFn: () => {
-        const url = `${END_POINT.GET_MATCH_DETAIL(matchId)}${typeof newRequest !== 'undefined' ? `?newRequest=${newRequest}` : ''}`;
-        return get(url);
+      queryFn: async () => {
+        const url = `${END_POINT.GET_MATCH_DETAIL(matchId)}${
+          typeof newRequest !== 'undefined' ? `?newRequest=${newRequest}` : ''
+        }`;
+
+        const res = await get<getMatchDetailResponse | ApiResponse<getMatchDetailResponse>>(url);
+
+        if (
+          typeof res === 'object' &&
+          res !== null &&
+          'status' in res &&
+          'message' in res &&
+          'data' in res
+        ) {
+          if (!res.data) {
+            throw new Error('매칭 요청 상세 응답 데이터가 없습니다.');
+          }
+
+          return res.data;
+        }
+
+        return res as getMatchDetailResponse;
       },
     }),
 

--- a/src/shared/components/card/match-card/constants/status.ts
+++ b/src/shared/components/card/match-card/constants/status.ts
@@ -1,6 +1,6 @@
 export const STATUS_KEYWORDS = {
   MATCHING_COMPLETE: '매칭 완료',
-  NEW_REQUEST: '새 요청',
+  NEW_REQUEST: '새요청',
   APPROVAL_COMPLETE: '승인 완료',
   FAILED: '실패',
   WAITING: '대기',

--- a/src/shared/components/card/match-card/constants/status.ts
+++ b/src/shared/components/card/match-card/constants/status.ts
@@ -8,7 +8,7 @@ export const STATUS_KEYWORDS = {
 
 export const MATCH_STATE = {
   CREATED: '매칭생성',
-  RECRUITING: '그룹원 모집 중',
+  RECRUITING: '그룹원 모집중',
   MATCHING_COMPLETE: '매칭완료',
   REQUESTED: '요청',
   WAITING: '수락 대기 중',

--- a/src/shared/components/card/match-card/utils/get-color-type.ts
+++ b/src/shared/components/card/match-card/utils/get-color-type.ts
@@ -5,14 +5,14 @@ export const getColorType = (status?: string, explicitColorType?: ChipColorType)
   if (explicitColorType) return explicitColorType;
   if (!status) return 'inactive';
 
-  if (
-    status.includes(STATUS_KEYWORDS.MATCHING_COMPLETE) ||
-    status.includes(STATUS_KEYWORDS.NEW_REQUEST)
-  )
-    return 'active';
+  if (status.includes(STATUS_KEYWORDS.NEW_REQUEST)) return 'update';
+
+  if (status.includes(STATUS_KEYWORDS.MATCHING_COMPLETE)) return 'active';
 
   if (status.includes(STATUS_KEYWORDS.APPROVAL_COMPLETE)) return 'outline';
+
   if (status.includes(STATUS_KEYWORDS.FAILED)) return 'dark';
+
   if (status.includes(STATUS_KEYWORDS.WAITING)) return 'inactive';
 
   return 'inactive';

--- a/src/shared/components/card/match-card/utils/get-match-current-step.ts
+++ b/src/shared/components/card/match-card/utils/get-match-current-step.ts
@@ -9,7 +9,7 @@ export const getMatchCurrentStep = (status?: string, matchTabType?: MatchTabType
         return 0;
       case '그룹원 모집중':
         return 1;
-      case '매칭완료':
+      case '완료':
         return 2;
       default:
         return 0;

--- a/src/shared/components/card/match-card/utils/get-match-current-step.ts
+++ b/src/shared/components/card/match-card/utils/get-match-current-step.ts
@@ -9,7 +9,7 @@ export const getMatchCurrentStep = (status?: string, matchTabType?: MatchTabType
         return 0;
       case '그룹원 모집중':
         return 1;
-      case '완료':
+      case '매칭완료':
         return 2;
       default:
         return 0;

--- a/src/shared/components/chip/styles/chip-state-variants.ts
+++ b/src/shared/components/chip/styles/chip-state-variants.ts
@@ -9,6 +9,7 @@ export const chipStateVariants = cva(
         inactive: 'bg-gray-200 text-gray-700',
         dark: 'bg-gray-800 text-gray-white',
         outline: 'bg-gray-white text-main-900 outline-[1px] outline-main-900',
+        update: 'bg-main-900 text-gray-white',
       },
     },
     defaultVariants: {

--- a/src/shared/components/header/header.tsx
+++ b/src/shared/components/header/header.tsx
@@ -9,8 +9,10 @@ interface HeaderProps {
 
 const Header = ({ headerTitle }: HeaderProps) => {
   const navigate = useNavigate();
-  const { pathname } = useLocation();
-  const urlParams = new URLSearchParams(location.search);
+  const { pathname, search } = useLocation();
+  const urlParams = new URLSearchParams(search);
+
+  const resultType = urlParams.get('type');
 
   const isFail = urlParams.get('type') === 'fail';
   const isSignUp = pathname.includes(ROUTES.SIGNUP);
@@ -23,6 +25,8 @@ const Header = ({ headerTitle }: HeaderProps) => {
   const isGame = Boolean(matchPath('/game/:date/:gameId', pathname));
   const isMemberDetail = Boolean(matchPath(ROUTES.MATCH_MEMBER_DETAIL(), pathname));
   const isProfile = pathname === ROUTES.PROFILE;
+  const isResult = Boolean(matchPath(ROUTES.RESULT(), pathname));
+  const isMatchingReceive = isResult && resultType === 'received';
 
   return (
     <header
@@ -35,7 +39,8 @@ const Header = ({ headerTitle }: HeaderProps) => {
           isGame ||
           isMatchSingle ||
           isMatchGroup ||
-          isMemberDetail,
+          isMemberDetail ||
+          isMatchingReceive,
       })}
     >
       {getHeaderContent(pathname, urlParams, isFail, navigate, headerTitle)}

--- a/src/shared/components/header/utils/get-header.tsx
+++ b/src/shared/components/header/utils/get-header.tsx
@@ -19,7 +19,7 @@ export const getHeaderContent = (
       matchPath(`${ROUTES.MATCH_CREATE}/*`, pathname) &&
       (urlParams.get('type') === 'single' || urlParams.get('type') === 'group');
 
-    const goMatchTypes = ['fail', 'agree', 'success', 'receive'];
+    const goMatchTypes = ['fail', 'agree', 'success', 'received'];
 
     if (pathname === ROUTES.RESULT()) {
       if (type === 'sent') {

--- a/src/shared/constants/header.ts
+++ b/src/shared/constants/header.ts
@@ -14,8 +14,6 @@ export const NO_HEADER_PATHS = [
   ROUTES.ONBOARDING_GROUP,
 
   ROUTES.CHAT,
-
-  ROUTES.RESULT(),
 ];
 
 export const SHOW_BOTTOM_NAVIGATE_PATHS = [

--- a/src/shared/routes/layout.tsx
+++ b/src/shared/routes/layout.tsx
@@ -13,13 +13,21 @@ const Layout = () => {
   useAnalyticsPageView();
 
   const { pathname, search } = useLocation();
-  const params = new URLSearchParams(search);
+  const searchParams = new URLSearchParams(search);
 
+  const resultType = searchParams.get('type');
+
+  const isResult = Boolean(matchPath({ path: ROUTES.RESULT(), end: true }, pathname));
   const isFail =
-    matchPath({ path: '/result/:id', end: true }, pathname) && params.get('type') === 'fail';
+    matchPath({ path: '/result/:id', end: true }, pathname) && searchParams.get('type') === 'fail';
+
+  const shouldHideResultHeader = isResult && resultType !== 'received';
+
+  const showHeader =
+    !NO_HEADER_PATHS.some((path) => matchPath({ path, end: true }, pathname)) &&
+    !shouldHideResultHeader;
 
   const showBottomNav = SHOW_BOTTOM_NAVIGATE_PATHS.includes(pathname);
-  const showHeader = !NO_HEADER_PATHS.some((path) => matchPath({ path, end: true }, pathname));
 
   const [isLoading, setIsLoading] = useState(false);
   const [headerTitle, setHeaderTitle] = useState('');


### PR DESCRIPTION
## #️⃣ Related Issue

Closes #428 

## 💎 PR Point

1. 생성한 매칭 카드에서 새 요청 클릭 시 요청 상세 화면으로 이동
2. MatchingReceiveView 구현 및 요청 수락/거절 처리
3. Result 페이지 헤더 조건 분기
4. SentView에서 "매칭 현황" 버튼 클릭 시 요청한 매칭 탭으로 이동
5. 그룹 매칭 멤버 캐러셀 인디케이터 조건 개선
6. Match 탭 sticky 영역과 카드 스크롤 레이어 조정

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 승인 대기 중 상태의 토스트 메시지가 정상적으로 표시되도록 수정
  
* **개선 사항**
  * 매칭 카드 클릭 시 상태 판단 로직 개선으로 더 정확한 네비게이션 제공
  * 캐러셀 인디케이터가 필요한 경우에만 표시되도록 최적화
  * 매칭 요청 수락 후 일관된 화면 전환 흐름 구현
  * 매칭 결과 페이지 헤더 표시 로직 개선
  * 상태 메시지 텍스트 정규화로 UI 일관성 강화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MATEBALL/MATEBALL-CLIENT/pull/429?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->